### PR TITLE
Refactor: split CI workflow into test/build-debug/build-release

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,37 @@
+name: Setup Flutter
+description: Flutter SDK setup, dependency install, .env creation, and code generation
+
+inputs:
+  flutter-version:
+    description: Flutter SDK version
+    default: "3.29.3"
+  api-base-url:
+    description: API_BASE_URL for .env file
+    default: "https://example.com"
+  working-directory:
+    description: Working directory
+    default: frontend
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: ${{ inputs.flutter-version }}
+        cache: true
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: flutter pub get
+
+    - name: Create .env
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: echo "API_BASE_URL=${{ inputs.api-base-url }}" > .env
+
+    - name: Run code generation
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -1,0 +1,44 @@
+name: Build Debug APK
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-debug:
+    name: Debug APK + Firebase Distribution
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+        with:
+          api-base-url: ${{ secrets.API_BASE_URL }}
+
+      - name: Place google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > android/app/google-services.json
+
+      - name: Build APK (debug)
+        run: flutter build apk --debug
+
+      - name: Upload debug APK to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          file: frontend/build/app/outputs/flutter-apk/app-debug.apk
+          releaseNotes: "Debug build ${{ github.sha }}"
+          testers: oh.naoki0819@gmail.com

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,55 @@
+name: Build Release APK
+
+on:
+  push:
+    branches: ["release/*"]
+
+jobs:
+  build-release:
+    name: Release APK + Firebase Distribution
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+        with:
+          api-base-url: ${{ secrets.API_BASE_URL }}
+
+      - name: Place google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > android/app/google-services.json
+
+      - name: Set up Android signing (debug key for testing)
+        run: |
+          mkdir -p ${HOME}/.android
+          echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 --decode > ${HOME}/.android/debug.keystore
+          cat <<EOF > android/key.properties
+          storePassword=android
+          keyPassword=android
+          keyAlias=androiddebugkey
+          storeFile=${HOME}/.android/debug.keystore
+          EOF
+
+      - name: Build APK (release)
+        run: flutter build apk --release
+
+      - name: Upload release APK to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          file: frontend/build/app/outputs/flutter-apk/app-release.apk
+          releaseNotes: "Release build ${{ github.sha }}"
+          testers: oh.naoki0819@gmail.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  # ──────────────────────────────────────────
+  # Backend: RSpec
+  # ──────────────────────────────────────────
+  backend-test:
+    name: Backend (RSpec)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: backend_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/backend_test
+      GOOGLE_CLIENT_ID: dummy_client_id_for_ci
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.1"
+          bundler-cache: true
+          working-directory: backend
+
+      - name: Set up database
+        run: bundle exec rails db:schema:load
+
+      - name: Run RSpec
+        run: bundle exec rspec
+
+  # ──────────────────────────────────────────
+  # Frontend: Flutter test
+  # ──────────────────────────────────────────
+  flutter-test:
+    name: Frontend (flutter test)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
+
+      - name: Run tests
+        run: flutter test


### PR DESCRIPTION
## Summary
- `ci.yml` を3つの専用ワークフローに分割し、責務を明確化
  - `test.yml`: backend RSpec + flutter test（全PR + main push）
  - `build-debug.yml`: debug APK ビルド + Firebase 配布（main push のみ）
  - `build-release.yml`: release APK ビルド + Firebase 配布（`release/*` push のみ）
- Flutter セットアップ（4ステップ）を composite action に抽出し重複排除
- 脆い `if: contains(...)` 条件分岐を廃止、ワークフロートリガーで制御

## Test plan
- [ ] feature ブランチで PR 作成 → `test.yml` のみ発火（backend-test + flutter-test）
- [ ] main にマージ → `test.yml` + `build-debug.yml` + `deploy-production.yml` が発火
- [ ] `release/*` ブランチに push → `build-release.yml` が発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)