### PR TITLE
Fix: GOOGLE_CLIENT_ID nil default allows audience verification bypass

### DIFF
--- a/backend/app/services/google_auth_service.rb
+++ b/backend/app/services/google_auth_service.rb
@@ -1,7 +1,7 @@
 require 'googleauth/id_tokens/verifier'
 
 class GoogleAuthService
-  GOOGLE_CLIENT_ID = ENV.fetch('GOOGLE_CLIENT_ID', nil)
+  GOOGLE_CLIENT_ID = ENV.fetch('GOOGLE_CLIENT_ID')
 
   def initialize(id_token)
     @id_token = id_token
@@ -19,7 +19,7 @@ class GoogleAuthService
   rescue Google::Auth::IDTokens::VerificationError => e
     raise Grape::Exceptions::Validation.new(
       params: ['id_token'],
-      message: "Invalid Google ID token: #{e.message}"
+      message: 'Invalid Google ID token'
     )
   end
 


### PR DESCRIPTION
## Summary

- `ENV.fetch('GOOGLE_CLIENT_ID', nil)` のデフォルト `nil` を削除。環境変数未設定の場合、`aud: nil` が渡され Google ID トークンの audience 検証がスキップされる可能性があった
- 未設定時は起動時に `KeyError` を raise するよう変更（フェイルファストで安全側に倒す）
- エラーメッセージから内部の Google 検証エラー詳細（`e.message`）を除去

## Security Impact

**Critical**: `GOOGLE_CLIENT_ID` が未設定の環境では、任意の Google アプリの ID トークンでログインできてしまう可能性があった。

## Test plan

- [ ] `GOOGLE_CLIENT_ID` を設定せずにサーバー起動 → `KeyError` で起動失敗することを確認
- [ ] 無効な ID トークンで `POST /auth/google` → エラーメッセージに内部詳細が含まれないことを確認
- [ ] 正常な Google ログインが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)