### PR TITLE
Fix: medium-priority security hardening

### DIFF
--- a/backend/app/api/v1/workout_results.rb
+++ b/backend/app/api/v1/workout_results.rb
@@ -47,6 +47,16 @@ module V1
         end
       end
       post do
+        if params[:workout_block_results].present? && params[:workout_block_results].size > 100
+          error!('Too many workout_block_results', 422)
+        end
+
+        if params[:workout_block_results].present?
+          valid_block_ids = WorkoutBlock.where(workout_summary_id: params[:workout_summary_id]).pluck(:id).to_set
+          invalid = params[:workout_block_results].map { |br| br[:workout_block_id] }.reject { |id| valid_block_ids.include?(id) }
+          error!("Invalid workout_block_id(s): #{invalid.join(', ')}", 422) if invalid.any?
+        end
+
         result = current_user.workout_results.new(
           workout_summary_id: params[:workout_summary_id],
           started_at: params[:started_at],

--- a/backend/app/models/user_ftp.rb
+++ b/backend/app/models/user_ftp.rb
@@ -1,5 +1,5 @@
 class UserFtp < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :ftp_value, presence: true, numericality: { greater_than: 0 }
+  validates :ftp_value, presence: true, numericality: { greater_than: 0, less_than_or_equal_to: 2000 }
 end

--- a/backend/config/initializers/rack_attack.rb
+++ b/backend/config/initializers/rack_attack.rb
@@ -7,9 +7,14 @@ class Rack::Attack
     req.ip == '127.0.0.1' || req.ip == '::1'
   end
 
-  # Throttle by IP: e.g., 100 requests per 1 minute per IP
+  # Throttle by IP: 100 requests per 1 minute per IP
   throttle('req/ip', limit: 100, period: 1.minute) do |req|
     req.ip
+  end
+
+  # Strict throttle for auth endpoint: 10 attempts per minute per IP
+  throttle('auth/ip', limit: 10, period: 1.minute) do |req|
+    req.ip if req.path == '/api/v1/auth/google' && req.post?
   end
 end
 


### PR DESCRIPTION
## Summary

- **レートリミット強化**: `POST /auth/google` に専用のthrottle追加（10回/分/IP）。既存の一般制限(100回/分)より厳しくし、ブルートフォースを防ぐ
- **FTP値の上限追加**: `user_ftp.rb` に `<= 2000W` のバリデーション追加（既存の `> 0` に加えて）
- **workout_block_results の入力検証**:
  - 100件超のリクエストを拒否（DoS対策）
  - `workout_block_id` が指定した `workout_summary_id` に属するか検証（不正な紐付けを防ぐ）

## Test plan

- [ ] `POST /auth/google` に11回/分リクエスト → 11回目が 429 になることを確認
- [ ] `ftp_value: 2001` で POST → 422 エラー
- [ ] `workout_block_id` に別ワークアウトのブロックIDを指定 → 422 エラー
- [ ] `workout_block_results` を101件送信 → 422 エラー
- [ ] RSpec 全テストが通ること（53 examples, 0 failures 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)