### PR TITLE
feat: workflow_dispatchでApp Distribution手動リリースを追加

### DIFF
--- a/.github/workflows/release-app-distribution.yml
+++ b/.github/workflows/release-app-distribution.yml
@@ -1,0 +1,94 @@
+name: Release to App Distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: "Build type"
+        required: true
+        default: "debug"
+        type: choice
+        options:
+          - debug
+          - release
+      release_notes:
+        description: "Release notes"
+        required: false
+        default: ""
+
+jobs:
+  release:
+    name: Build & Distribute
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.29.3"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run code generation
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Create .env
+        run: echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" > .env
+
+      - name: Place google-services.json
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > android/app/google-services.json
+
+      # Debug build
+      - name: Build APK (debug)
+        if: inputs.build_type == 'debug'
+        run: flutter build apk --debug
+
+      - name: Upload debug APK to Firebase App Distribution
+        if: inputs.build_type == 'debug'
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          file: frontend/build/app/outputs/flutter-apk/app-debug.apk
+          releaseNotes: "${{ inputs.release_notes || format('Debug build {0} ({1})', github.ref_name, github.sha) }}"
+          testers: oh.naoki0819@gmail.com
+
+      # Release build
+      - name: Set up Android signing
+        if: inputs.build_type == 'release'
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode --ignore-garbage > android/app/workoutride.keystore
+          cat <<EOF > android/key.properties
+          storePassword=${{ secrets.STORE_PASSWORD }}
+          keyPassword=${{ secrets.KEY_PASSWORD }}
+          keyAlias=workoutride
+          storeFile=workoutride.keystore
+          EOF
+
+      - name: Build APK (release)
+        if: inputs.build_type == 'release'
+        run: flutter build apk --release
+
+      - name: Upload release APK to Firebase App Distribution
+        if: inputs.build_type == 'release'
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          file: frontend/build/app/outputs/flutter-apk/app-release.apk
+          releaseNotes: "${{ inputs.release_notes || format('Release build {0} ({1})', github.ref_name, github.sha) }}"
+          testers: oh.naoki0819@gmail.com


### PR DESCRIPTION
## Summary

- GitHub UIからブランチを選択してFirebase App Distributionへ手動配布できるワークフローを追加
- debug / release ビルドタイプを選択可能
- リリースノートをカスタム入力可能（未入力時はブランチ名+SHAが自動設定）

## Test plan

- [ ] mainにマージ後、GitHub Actions > Release to App Distribution > Run workflow からブランチとビルドタイプを選択して実行
- [ ] debugビルドでApp Distributionに配布されることを確認
- [ ] releaseビルドでApp Distributionに配布されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)