### PR TITLE
feat: ワークアウト中に画面スリープを防止

### DIFF
--- a/frontend/lib/ui/workout/workout_screen.dart
+++ b/frontend/lib/ui/workout/workout_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:workoutride/component/meter.dart';
 import 'package:workoutride/ui/workout/developer_menu.dart';
 import 'package:workoutride/ui/workout/workout_screen_state_notifier.dart';
@@ -18,7 +19,14 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
   final ScrollController _scrollController = ScrollController();
 
   @override
+  void initState() {
+    super.initState();
+    WakelockPlus.enable();
+  }
+
+  @override
   void dispose() {
+    WakelockPlus.disable();
     _scrollController.dispose();
     super.dispose();
   }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -741,6 +741,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -1138,6 +1154,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  wakelock_plus:
+    dependency: "direct main"
+    description:
+      name: wakelock_plus
+      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  wakelock_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   google_sign_in: ^6.2.1
   flutter_secure_storage: ^9.2.2
   flutter_dotenv: ^5.2.1
+  wakelock_plus: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- `wakelock_plus` パッケージを追加
- ワークアウト画面の表示中は画面スリープを無効化
- 画面を離れる（dispose）と自動で解除

## Test plan

- [ ] ワークアウトを開始し、操作せずに放置しても画面がスリープしないことを確認
- [ ] ワークアウトを終了/停止した後、通常通りスリープすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)