### PR TITLE
fix: Kotlinバージョンを2.1.0に更新

### DIFF
--- a/frontend/android/settings.gradle
+++ b/frontend/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.3.2" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary

- Kotlin Gradleプラグインを 2.0.20 → 2.1.0 に更新
- `package_info_plus` 等の依存がKotlin 2.2.0メタデータを含むため、互換性のあるバージョンに更新

## Test plan

- [ ] CIのflutter build apkが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)