### PR TITLE
fix: AGPを8.7.3に更新（releaseビルドのR8エラー修正）

### DIFF
--- a/frontend/android/gradle/wrapper/gradle-wrapper.properties
+++ b/frontend/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/frontend/android/settings.gradle
+++ b/frontend/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.2" apply false
+    id "com.android.application" version "8.7.3" apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 


### PR DESCRIPTION
## Summary

- AGP (Android Gradle Plugin) を 8.3.2 → 8.7.3 に更新
- AGP 8.3.2 の R8 は Kotlin メタデータ 2.0.0 までしかサポートしておらず、`wakelock_plus` / `package_info_plus` が依存する `kotlin-stdlib 2.2.0` のメタデータを処理できず release ビルドが失敗していた

## Test plan

- [ ] CIの flutter build apk (debug) が成功すること
- [ ] workflow_dispatch で release ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)