### PR TITLE
fix: google-services.json / GoogleService-Info.plist を gitignore に追加

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -47,5 +47,6 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-# Google Services (contains OAuth client IDs)
-android/app/google-services.json
+# Google Services (contains OAuth client IDs and API keys)
+**/google-services.json
+**/GoogleService-Info.plist


### PR DESCRIPTION
## Summary

- `frontend/.gitignore` の `android/app/google-services.json` パターンが `src/debug/` や `src/release/` 配下のファイルにマッチしていなかった
- Firebase API キーや OAuth クライアント ID を含む `google-services.json` が誤ってコミットされるリスクがあった
- `**/google-services.json` に変更してサブディレクトリにも対応
- iOS 向けに `**/GoogleService-Info.plist` も追加

## Test plan

- [ ] `frontend/android/app/src/debug/google-services.json` が `git status` で untracked のまま（tracked にならない）ことを確認
- [ ] `frontend/android/app/src/release/google-services.json` が `git status` で untracked のまま（tracked にならない）ことを確認
- [ ] `git add .` しても上記ファイルが staging されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)