### PR TITLE
feat: Cloudflare Origin Certificate でバックエンドをドメイン化

### DIFF
--- a/backend/.kamal/secrets
+++ b/backend/.kamal/secrets
@@ -1,3 +1,5 @@
 KAMAL_REGISTRY_PASSWORD=$(gcloud auth print-access-token)
 RAILS_MASTER_KEY=$(gcloud secrets versions access latest --secret=RAILS_MASTER_KEY)
 BACKEND_DATABASE_PASSWORD=$(gcloud secrets versions access latest --secret=BACKEND_DATABASE_PASSWORD)
+CLOUDFLARE_ORIGIN_CERT=$(gcloud secrets versions access latest --secret=CLOUDFLARE_ORIGIN_CERT)
+CLOUDFLARE_ORIGIN_KEY=$(gcloud secrets versions access latest --secret=CLOUDFLARE_ORIGIN_KEY)

--- a/backend/config/deploy.yml
+++ b/backend/config/deploy.yml
@@ -8,8 +8,10 @@ servers:
 deploy_timeout: 120
 
 proxy:
-  ssl: true
-  host: 34.138.232.78.nip.io
+  host: api.workoutride.ohnaoki.app
+  ssl:
+    certificate_pem: CLOUDFLARE_ORIGIN_CERT
+    private_key_pem: CLOUDFLARE_ORIGIN_KEY
   healthcheck:
     path: /up
     interval: 5

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
 # API Base URL
-API_BASE_URL=https://34.138.232.78.nip.io/api/v1
+API_BASE_URL=https://api.workoutride.ohnaoki.app/api/v1
 DEBUG_AUTH_TOKEN=


### PR DESCRIPTION
## Summary

公開に向けてバックエンドをドメイン化し、Cloudflare プロキシ経由で **オリジンIP秘匿・WAF/DDoS緩和** を効かせる構成変更。

- `deploy.yml`: `proxy.host` を `34.138.232.78.nip.io` → `api.workoutride.ohnaoki.app` に変更
- SSL を Let's Encrypt 自動取得 → **Cloudflare Origin Certificate（15年有効）** に切替
  - Cloudflare プロキシ（オレンジ雲）下では Let's Encrypt の自動更新が challenge を受け取れず失敗するため
  - 証明書/鍵は `CLOUDFLARE_ORIGIN_CERT` / `CLOUDFLARE_ORIGIN_KEY` シークレット参照
- `.kamal/secrets`: 上記2シークレットを gcloud Secret Manager から取得する行を追加
  - デプロイSA `workoutride-backend@` はプロジェクトレベルで `secretAccessor` 保持済み → 追加IAM不要
- `frontend/.env.example`: `API_BASE_URL` を新ドメインに更新

SSH接続用のサーバーIP（`servers.web`, `ssh-keyscan`）はサーバー直結のため変更なし。

## デプロイ手順（マージ後）

1. ⚪️ **Cloudflare は DNS only（グレー）のまま** この PR をマージ → GHA が自動 `kamal deploy`
2. 新ドメインで Origin 証明書が出ているか検証
3. 問題なければ 🟠 **Proxied（オレンジ）+ SSL: Full (strict)** に切替（IP秘匿・WAF有効化）

## 残作業（別途）

- [ ] CI/CD の GitHub Secret `API_BASE_URL` を新ドメインに更新（リリースビルド用）
- [ ] ローカル `frontend/.env` を新ドメインに更新（各自）
- [ ] （推奨）GCP ファイアウォールで 80/443 を Cloudflare IP レンジのみ許可

🤖 Generated with [Claude Code](https://claude.com/claude-code)