### PR TITLE
fix: バックエンドのホストを workoutride.ohnaoki.app に変更（無料SSL対応）

### DIFF
--- a/backend/config/deploy.yml
+++ b/backend/config/deploy.yml
@@ -8,7 +8,7 @@ servers:
 deploy_timeout: 120
 
 proxy:
-  host: api.workoutride.ohnaoki.app
+  host: workoutride.ohnaoki.app
   ssl:
     certificate_pem: CLOUDFLARE_ORIGIN_CERT
     private_key_pem: CLOUDFLARE_ORIGIN_KEY

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
 # API Base URL
-API_BASE_URL=https://api.workoutride.ohnaoki.app/api/v1
+API_BASE_URL=https://workoutride.ohnaoki.app/api/v1
 DEBUG_AUTH_TOKEN=


### PR DESCRIPTION
## Summary

`api.workoutride.ohnaoki.app`（2階層サブドメイン）は Cloudflare の無料 Universal SSL（`*.ohnaoki.app` の1階層のみ）の対象外で、エッジで TLS ハンドシェイクが失敗していた。

1階層の **`workoutride.ohnaoki.app`** に変更して無料SSLを有効化。

- `deploy.yml`: `proxy.host` → `workoutride.ohnaoki.app`
- `frontend/.env.example`: `API_BASE_URL` 更新
- **Origin証明書の再作成は不要**（既存証明書のSANに `workoutride.ohnaoki.app` を含む）
- ローカルで `kamal config` がエラーなく通ることを確認済み

## マージ後

`main` への push で再デプロイ → 新ホストで検証 → Cloudflare 🟠 + Full(strict) で IP秘匿/WAF確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)