### PR TITLE
chore: 内部インフラ解説docを gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ backend/test_auth_manual.md
 docs/cicd-plan.md
 docs/pre-release-fixes.md
 docs/workoutride-gcp-infra-1.html
+docs/infra-why-explained.md
 
 # Coverage
 coverage/


### PR DESCRIPTION
## Summary

`docs/infra-why-explained.md`（インフラ構成の「なぜ」を初学者向けに解説した内部資料）を gitignore に追加。手元には残しつつ、公開リポジトリには含めない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)