### PR TITLE
feat: アカウント削除機能を追加（Google Play 必須要件）

### DIFF
--- a/backend/app/api/v1/auth.rb
+++ b/backend/app/api/v1/auth.rb
@@ -32,6 +32,13 @@ module V1
         { message: 'Logged out successfully' }
       end
 
+      desc 'Delete account and all associated data'
+      delete :account do
+        authenticate!
+        current_user.destroy!
+        { message: 'Account deleted successfully' }
+      end
+
       desc 'Get current user'
       get :me do
         authenticate!

--- a/backend/spec/requests/api/v1/auth_spec.rb
+++ b/backend/spec/requests/api/v1/auth_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::Auth', type: :request do
+  let(:user) { User.create!(provider: 'google', uid: '12345') }
+  let!(:auth_token) { user.auth_tokens.create! }
+  let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
+
+  describe 'DELETE /v1/auth/account' do
+    let(:workout_summary) { create(:workout_summary) }
+
+    before do
+      user.user_ftps.create!(ftp_value: 250)
+      result = user.workout_results.create!(
+        workout_summary: workout_summary,
+        started_at: Time.current,
+        total_duration_seconds: 600,
+        status: 'completed'
+      )
+      block = create(:workout_block, workout_summary: workout_summary)
+      result.workout_block_results.create!(
+        workout_block_id: block.id,
+        duration_seconds: 300
+      )
+    end
+
+    it 'deletes the user and all associated data' do
+      expect {
+        delete '/api/v1/auth/account', headers: headers
+      }.to change(User, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(AuthToken.where(user_id: user.id)).to be_empty
+      expect(WorkoutResult.where(user_id: user.id)).to be_empty
+      expect(UserFtp.where(user_id: user.id)).to be_empty
+      expect(WorkoutBlockResult.count).to eq(0)
+    end
+
+    it 'does not delete other users or their data' do
+      other_user = User.create!(provider: 'google', uid: '67890')
+      other_user.user_ftps.create!(ftp_value: 200)
+
+      delete '/api/v1/auth/account', headers: headers
+
+      expect(User.exists?(other_user.id)).to be(true)
+      expect(other_user.user_ftps.count).to eq(1)
+    end
+
+    context 'without authentication' do
+      it 'returns 401' do
+        delete '/api/v1/auth/account'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'DELETE /v1/auth/logout' do
+    it 'destroys the auth token' do
+      expect {
+        delete '/api/v1/auth/logout', headers: headers
+      }.to change { user.auth_tokens.count }.by(-1)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'without authentication' do
+      it 'returns 401' do
+        delete '/api/v1/auth/logout'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET /v1/auth/me' do
+    it 'returns the current user' do
+      get '/api/v1/auth/me', headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq(user.id)
+      expect(json['provider']).to eq('google')
+      expect(json['uid']).to eq('12345')
+    end
+
+    context 'with an expired token' do
+      it 'returns 401' do
+        auth_token.update!(expires_at: 1.hour.ago)
+
+        get '/api/v1/auth/me', headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/frontend/lib/data/remote/api/auth_api_client.dart
+++ b/frontend/lib/data/remote/api/auth_api_client.dart
@@ -15,6 +15,9 @@ abstract class AuthApiClient {
   @DELETE("/auth/logout")
   Future<void> logout();
 
+  @DELETE("/auth/account")
+  Future<void> deleteAccount();
+
   @GET("/auth/me")
   Future<UserDto> getCurrentUser();
 }

--- a/frontend/lib/data/remote/api/auth_api_client.g.dart
+++ b/frontend/lib/data/remote/api/auth_api_client.g.dart
@@ -81,6 +81,31 @@ class _AuthApiClient implements AuthApiClient {
   }
 
   @override
+  Future<void> deleteAccount() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<void>(Options(
+      method: 'DELETE',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/auth/account',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    await _dio.fetch<void>(_options);
+  }
+
+  @override
   Future<UserDto> getCurrentUser() async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};

--- a/frontend/lib/data/repository/auth_repository_impl.dart
+++ b/frontend/lib/data/repository/auth_repository_impl.dart
@@ -53,6 +53,15 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<void> deleteAccount() async {
+    // サーバー側の削除が成功した場合のみローカルの認証情報を破棄する
+    await _apiClient.deleteAccount();
+
+    await _googleSignIn.signOut();
+    await _secureStorage.delete(key: _tokenKey);
+  }
+
+  @override
   Future<User?> getCurrentUser() async {
     final token = await _secureStorage.read(key: _tokenKey);
     if (token == null) return null;

--- a/frontend/lib/di/providers.g.dart
+++ b/frontend/lib/di/providers.g.dart
@@ -547,7 +547,7 @@ final powerZoneAnalyzerProvider =
 // ignore: unused_element
 typedef PowerZoneAnalyzerRef = AutoDisposeProviderRef<PowerZoneAnalyzer>;
 String _$manageWorkoutUseCaseHash() =>
-    r'f96f0886246869b6abeadf9f46fd34766da59a15';
+    r'81a64cd8d4d41dbd1b07def68600c9806ce58478';
 
 /// See also [manageWorkoutUseCase].
 @ProviderFor(manageWorkoutUseCase)

--- a/frontend/lib/domain/repository/auth_repository.dart
+++ b/frontend/lib/domain/repository/auth_repository.dart
@@ -3,5 +3,6 @@ import 'package:workoutride/domain/model/auth/user.dart';
 abstract class AuthRepository {
   Future<User> signInWithGoogle();
   Future<void> signOut();
+  Future<void> deleteAccount();
   Future<User?> getCurrentUser();
 }

--- a/frontend/lib/ui/auth/auth_state_notifier.dart
+++ b/frontend/lib/ui/auth/auth_state_notifier.dart
@@ -37,6 +37,12 @@ class AuthStateNotifier extends _$AuthStateNotifier {
     state = const AsyncValue.data(AuthState.unauthenticated());
   }
 
+  /// アカウントと全データを削除する。失敗時は例外を投げ、認証状態は変えない。
+  Future<void> deleteAccount() async {
+    await ref.read(authRepositoryProvider).deleteAccount();
+    state = const AsyncValue.data(AuthState.unauthenticated());
+  }
+
   Future<void> signInAsDebugUser() async {
     assert(kDebugMode, 'signInAsDebugUser must only be called in debug mode');
     state = const AsyncValue.data(AuthState.loading());

--- a/frontend/lib/ui/auth/auth_state_notifier.g.dart
+++ b/frontend/lib/ui/auth/auth_state_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'auth_state_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authStateNotifierHash() => r'8a735d527137bf7bd31487da96a04f32f6dae306';
+String _$authStateNotifierHash() => r'd3fdf901dcf9ea88e8f675347aa995c15f78c698';
 
 /// See also [AuthStateNotifier].
 @ProviderFor(AuthStateNotifier)

--- a/frontend/lib/ui/settings/settings_screen.dart
+++ b/frontend/lib/ui/settings/settings_screen.dart
@@ -82,6 +82,28 @@ class SettingsScreen extends ConsumerWidget {
     }
   }
 
+  Future<void> _showDeleteAccountDialog(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => const _DeleteAccountConfirmDialog(),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    try {
+      await ref.read(authStateNotifierProvider.notifier).deleteAccount();
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('アカウントの削除に失敗しました。通信状況を確認して再度お試しください。'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final uiState = ref.watch(settingsScreenStateNotifierProvider);
@@ -169,6 +191,13 @@ class SettingsScreen extends ConsumerWidget {
                         icon: Icons.logout,
                         onTap: () => _showLogoutDialog(context, ref),
                       ),
+                      const SizedBox(height: 16),
+                      _buildDangerSettingTile(
+                        title: 'アカウント削除',
+                        subtitle: 'アカウントとワークアウト履歴などの全データを完全に削除します',
+                        icon: Icons.delete_forever,
+                        onTap: () => _showDeleteAccountDialog(context, ref),
+                      ),
                     ],
                   ),
                 ),
@@ -250,6 +279,70 @@ class SettingsScreen extends ConsumerWidget {
         trailing: const Icon(Icons.chevron_right, color: Colors.red),
         onTap: onTap,
       ),
+    );
+  }
+}
+
+/// アカウント削除の確認ダイアログ。「削除」と入力しないと実行できない。
+class _DeleteAccountConfirmDialog extends StatefulWidget {
+  const _DeleteAccountConfirmDialog();
+
+  @override
+  State<_DeleteAccountConfirmDialog> createState() =>
+      _DeleteAccountConfirmDialogState();
+}
+
+class _DeleteAccountConfirmDialogState
+    extends State<_DeleteAccountConfirmDialog> {
+  final _controller = TextEditingController();
+  bool _canDelete = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('アカウント削除'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'アカウントを削除すると、ワークアウト履歴・FTP・体重などの全データが完全に削除されます。この操作は取り消せません。',
+          ),
+          const SizedBox(height: 16),
+          const Text('続行するには「削除」と入力してください。'),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _controller,
+            decoration: const InputDecoration(
+              hintText: '削除',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (value) {
+              setState(() {
+                _canDelete = value.trim() == '削除';
+              });
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed:
+              _canDelete ? () => Navigator.of(context).pop(true) : null,
+          style: TextButton.styleFrom(foregroundColor: Colors.red),
+          child: const Text('完全に削除する'),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 概要
Google Play のアカウント削除ポリシー対応として、アプリ内からアカウントと全データを削除できる機能を追加します。

## 変更内容
### バックエンド
- `DELETE /api/v1/auth/account`: 認証ユーザー本人と関連データ（auth_tokens / workout_results / workout_block_results / user_ftps）を `dependent: :destroy` で完全削除
- Auth API のリクエストスペックを新規追加（アカウント削除・他ユーザーへの影響なし・未認証401・ログアウト・me・期限切れトークン）

### フロントエンド
- 設定画面の「アカウント」セクションに「アカウント削除」を追加
- 誤操作防止のため「削除」と入力しないと実行できない確認ダイアログ
- サーバー側の削除成功後にのみローカルの認証情報を破棄し、失敗時はSnackBarで通知（認証状態は維持）

## テスト
- `bundle exec rspec`: 60 examples, 0 failures
- `flutter analyze`: エラーなし / `flutter test`: 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)