### PR TITLE
feat(backend): 認証トークンをSHA-256ダイジェストでDB保存

### DIFF
--- a/backend/app/api/helpers/auth_helper.rb
+++ b/backend/app/api/helpers/auth_helper.rb
@@ -14,7 +14,7 @@ module Helpers
       token = extract_token_from_header
       return nil unless token
 
-      auth_token = AuthToken.includes(:user).active.find_by(token: token)
+      auth_token = AuthToken.find_active_by_raw_token(token)
       return nil unless auth_token
 
       auth_token.touch_last_used!

--- a/backend/app/api/v1/auth.rb
+++ b/backend/app/api/v1/auth.rb
@@ -28,7 +28,7 @@ module V1
       delete :logout do
         authenticate!
         token = extract_token_from_header
-        current_user.auth_tokens.find_by(token: token)&.destroy
+        current_user.auth_tokens.find_by(token_digest: AuthToken.digest(token))&.destroy
         { message: 'Logged out successfully' }
       end
 

--- a/backend/app/models/auth_token.rb
+++ b/backend/app/models/auth_token.rb
@@ -1,9 +1,20 @@
 class AuthToken < ApplicationRecord
   belongs_to :user
 
+  # 生トークンは作成直後のレスポンス用にメモリ上でのみ保持し、DBにはダイジェストだけを保存する
+  attr_reader :token
+
   before_create :generate_token, :set_expiration
 
   scope :active, -> { where('expires_at > ?', Time.current) }
+
+  def self.digest(raw_token)
+    Digest::SHA256.hexdigest(raw_token)
+  end
+
+  def self.find_active_by_raw_token(raw_token)
+    includes(:user).active.find_by(token_digest: digest(raw_token))
+  end
 
   def expired?
     expires_at < Time.current
@@ -16,7 +27,8 @@ class AuthToken < ApplicationRecord
   private
 
   def generate_token
-    self.token = SecureRandom.hex(32)
+    @token = SecureRandom.hex(32)
+    self.token_digest = self.class.digest(@token)
   end
 
   def set_expiration

--- a/backend/db/migrate/20260712090000_hash_auth_tokens.rb
+++ b/backend/db/migrate/20260712090000_hash_auth_tokens.rb
@@ -1,0 +1,23 @@
+class HashAuthTokens < ActiveRecord::Migration[8.0]
+  def up
+    add_column :auth_tokens, :token_digest, :string
+
+    # 既存トークンをハッシュ化し、発行済みセッションを無効化せずに移行する
+    select_rows('SELECT id, token FROM auth_tokens').each do |id, token|
+      digest = Digest::SHA256.hexdigest(token)
+      execute(
+        ActiveRecord::Base.sanitize_sql(
+          ['UPDATE auth_tokens SET token_digest = ? WHERE id = ?', digest, id]
+        )
+      )
+    end
+
+    change_column_null :auth_tokens, :token_digest, false
+    add_index :auth_tokens, :token_digest, unique: true
+    remove_column :auth_tokens, :token
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, '生トークンはダイジェストから復元できません'
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_08_025821) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_12_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "auth_tokens", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "token", null: false
     t.datetime "expires_at", null: false
     t.datetime "last_used_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["token"], name: "index_auth_tokens_on_token", unique: true
+    t.string "token_digest", null: false
+    t.index ["token_digest"], name: "index_auth_tokens_on_token_digest", unique: true
     t.index ["user_id", "expires_at"], name: "index_auth_tokens_on_user_id_and_expires_at"
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end

--- a/backend/spec/models/auth_token_spec.rb
+++ b/backend/spec/models/auth_token_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe AuthToken, type: :model do
+  let(:user) { User.create!(provider: 'google', uid: '12345') }
+
+  describe 'トークン生成' do
+    it '生トークンをメモリ上に、ダイジェストのみをDBに保存する' do
+      auth_token = user.auth_tokens.create!
+
+      expect(auth_token.token).to be_present
+      expect(auth_token.token_digest).to eq(described_class.digest(auth_token.token))
+      expect(auth_token.reload.attributes).not_to have_key('token')
+    end
+
+    it '生トークンはリロード後に取得できない' do
+      auth_token = user.auth_tokens.create!
+
+      expect(described_class.find(auth_token.id).token).to be_nil
+    end
+  end
+
+  describe '.find_active_by_raw_token' do
+    it '有効な生トークンでレコードを引ける' do
+      auth_token = user.auth_tokens.create!
+
+      found = described_class.find_active_by_raw_token(auth_token.token)
+      expect(found).to eq(auth_token)
+      expect(found.user).to eq(user)
+    end
+
+    it '期限切れトークンでは引けない' do
+      auth_token = user.auth_tokens.create!
+      auth_token.update!(expires_at: 1.hour.ago)
+
+      expect(described_class.find_active_by_raw_token(auth_token.token)).to be_nil
+    end
+
+    it '不正なトークンでは引けない' do
+      user.auth_tokens.create!
+
+      expect(described_class.find_active_by_raw_token('invalid-token')).to be_nil
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/user_ftps_spec.rb
+++ b/backend/spec/requests/api/v1/user_ftps_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'V1::UserFtps', type: :request do
   let(:user) { User.create!(provider: 'google', uid: '12345') }
-  let(:auth_token) { user.auth_tokens.create!(token: SecureRandom.hex(32), expires_at: 30.days.from_now) }
+  let(:auth_token) { user.auth_tokens.create! }
   let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
 
   describe 'GET /v1/user_ftps/current' do

--- a/backend/spec/requests/api/v1/workout_blocks_spec.rb
+++ b/backend/spec/requests/api/v1/workout_blocks_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'API::V1::WorkoutBlocks', type: :request do
   let(:user) { User.create!(provider: 'google', uid: '12345') }
-  let(:auth_token) { user.auth_tokens.create!(token: SecureRandom.hex(32), expires_at: 30.days.from_now) }
+  let(:auth_token) { user.auth_tokens.create! }
   let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
 
   describe 'GET /api/v1/workout_blocks/:id' do

--- a/backend/spec/requests/api/v1/workout_results_spec.rb
+++ b/backend/spec/requests/api/v1/workout_results_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'V1::WorkoutResults', type: :request do
   let(:user) { User.create!(provider: 'google', uid: '12345') }
-  let(:auth_token) { user.auth_tokens.create!(token: SecureRandom.hex(32), expires_at: 30.days.from_now) }
+  let(:auth_token) { user.auth_tokens.create! }
   let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
 
   let!(:workout_summary) { create(:workout_summary) }

--- a/backend/spec/requests/api/v1/workout_summaries_spec.rb
+++ b/backend/spec/requests/api/v1/workout_summaries_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'API::V1::WorkoutSummaries', type: :request do
   let(:user) { User.create!(provider: 'google', uid: '12345') }
-  let(:auth_token) { user.auth_tokens.create!(token: SecureRandom.hex(32), expires_at: 30.days.from_now) }
+  let(:auth_token) { user.auth_tokens.create! }
   let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
 
   describe 'GET /api/v1/workout_summaries' do


### PR DESCRIPTION
## 概要
auth_tokens テーブルに平文で保存していたトークンを SHA-256 ダイジェスト保存に変更します。DB（Neon）が漏洩しても全ユーザーのセッションを乗っ取れなくなります。

## 変更内容
- `auth_tokens.token` カラムを廃止し `token_digest`（unique index付き）へ移行
- **既存トークンはマイグレーション内でハッシュ化するため、発行済みセッション（ログイン中ユーザー・`.env` の `DEBUG_AUTH_TOKEN`）はそのまま有効**
- 生トークンは作成直後のAPIレスポンス用にメモリ上でのみ保持（`attr_reader :token`）
- 認証は `AuthToken.find_active_by_raw_token`（ダイジェスト照合）に変更
- AuthToken のモデルスペックを追加、既存リクエストスペックを新しい生成方式に更新

## 注意
- マイグレーションは不可逆（ダイジェストから生トークンは復元不可）
- PR #79（アカウント削除）とは独立してマージ可能

## テスト
`bundle exec rspec`: 58 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)