### PR TITLE
fix(backend): レート制限を実クライアントIP単位に修正（Cloudflare対応）

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -45,7 +45,7 @@ module Backend
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    # Rate limiting middleware
-    config.middleware.use Rack::Attack
+    # Rack::Attack は gem の railtie が自動でミドルウェア登録するため、ここでは登録しない
+    # （二重登録するとレート制限のカウントが1リクエストで2進む）
   end
 end

--- a/backend/config/initializers/rack_attack.rb
+++ b/backend/config/initializers/rack_attack.rb
@@ -1,21 +1,26 @@
 # frozen_string_literal: true
 
 class Rack::Attack
+  # ActionDispatch::RemoteIp が算出した実クライアントIPを使う。
+  # req.ip（Rack標準）は Cloudflare のエッジIPを返すことがあり、その場合
+  # 全ユーザーが同じIPとしてカウントされてレート制限を共有してしまう。
+  # RemoteIp ミドルウェアは Rack::Attack より先に実行される（config/initializers/trusted_proxies.rb 参照）。
+  def self.client_ip(req)
+    (req.env['action_dispatch.remote_ip'] || req.ip).to_s
+  end
+
   # Allow local traffic (health checks, localhost)
   safelist('allow-localhost') do |req|
-    # fly.io, render, or local loopback
-    req.ip == '127.0.0.1' || req.ip == '::1'
+    client_ip(req) == '127.0.0.1' || client_ip(req) == '::1'
   end
 
   # Throttle by IP: 100 requests per 1 minute per IP
   throttle('req/ip', limit: 100, period: 1.minute) do |req|
-    req.ip
+    client_ip(req)
   end
 
   # Strict throttle for auth endpoint: 10 attempts per minute per IP
   throttle('auth/ip', limit: 10, period: 1.minute) do |req|
-    req.ip if req.path == '/api/v1/auth/google' && req.post?
+    client_ip(req) if req.path == '/api/v1/auth/google' && req.post?
   end
 end
-
-

--- a/backend/config/initializers/trusted_proxies.rb
+++ b/backend/config/initializers/trusted_proxies.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Cloudflare を経由したリクエストで実クライアントIPを取得するための設定。
+# Cloudflare のエッジIPを信頼済みプロキシとして扱わないと、remote_ip が
+# エッジIPを返してしまい、レート制限が全ユーザー共有になる・アクセスログが
+# 意味をなさない等の問題が起きる。
+#
+# IPレンジの出典: https://www.cloudflare.com/ips/ （変更は稀だが、更新時はここを差し替える）
+cloudflare_ip_ranges = %w[
+  173.245.48.0/20
+  103.21.244.0/22
+  103.22.200.0/22
+  103.31.4.0/22
+  141.101.64.0/18
+  108.162.192.0/18
+  190.93.240.0/20
+  188.114.96.0/20
+  197.234.240.0/22
+  198.41.128.0/17
+  162.158.0.0/15
+  104.16.0.0/13
+  104.24.0.0/14
+  172.64.0.0/13
+  131.0.72.0/22
+  2400:cb00::/32
+  2606:4700::/32
+  2803:f800::/32
+  2405:b500::/32
+  2405:8100::/32
+  2a06:98c0::/29
+  2c0f:f248::/32
+].map { |cidr| IPAddr.new(cidr) }
+
+# デフォルトの信頼済みプロキシ（ループバック・プライベートIP = kamal-proxy 等）に
+# Cloudflare のレンジを追加する
+Rails.application.config.action_dispatch.trusted_proxies =
+  ActionDispatch::RemoteIp::TRUSTED_PROXIES + cloudflare_ip_ranges

--- a/backend/spec/initializers/rack_attack_spec.rb
+++ b/backend/spec/initializers/rack_attack_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Rack::Attack do
+  describe '.client_ip' do
+    it 'RemoteIpが算出した実クライアントIPを優先する' do
+      req = Rack::Attack::Request.new(
+        'REMOTE_ADDR' => '104.16.0.1', # Cloudflare edge
+        'action_dispatch.remote_ip' => IPAddr.new('203.0.113.10')
+      )
+
+      expect(described_class.client_ip(req)).to eq('203.0.113.10')
+    end
+
+    it 'RemoteIpがない場合はreq.ipにフォールバックする' do
+      req = Rack::Attack::Request.new('REMOTE_ADDR' => '198.51.100.5')
+
+      expect(described_class.client_ip(req)).to eq('198.51.100.5')
+    end
+  end
+
+  describe 'trusted proxies設定' do
+    it 'CloudflareのIPレンジが信頼済みプロキシに含まれる' do
+      proxies = Rails.application.config.action_dispatch.trusted_proxies
+
+      expect(proxies.any? { |p| p.include?(IPAddr.new('104.16.0.1')) }).to be(true)
+      # ループバック（kamal-proxy等）も引き続き信頼される
+      expect(proxies.any? { |p| p.include?(IPAddr.new('127.0.0.1')) }).to be(true)
+      # 一般のグローバルIPは信頼されない
+      expect(proxies.any? { |p| p.include?(IPAddr.new('203.0.113.10')) }).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
本番はCloudflare経由のため、`req.ip` がCloudflareのエッジIPを返し、**全ユーザーが1つのIPとしてカウントされて100req/分を共有**する状態でした。ユーザーが少し増えるだけで正当なリクエストが429でブロックされます。

## 変更内容
1. **trusted_proxies に Cloudflare IPレンジを追加**（`config/initializers/trusted_proxies.rb`）
   - 出典: https://www.cloudflare.com/ips/
   - デフォルトの信頼済みプロキシ（ループバック・プライベートIP = kamal-proxy）は維持
2. **Rack::Attack が RemoteIp の算出結果を使うよう変更**
   - `req.ip`（Rack標準、trusted_proxiesを見ない）→ `req.env['action_dispatch.remote_ip']`
3. **Rack::Attack の二重登録を解消**
   - gem の railtie が自動登録するのに加えて `application.rb` でも `middleware.use` していたため、1リクエストでカウントが2進み実質レート制限が半分になっていた（`bin/rails middleware` で2行出ていたのが1行に）

## テスト
- client_ip の優先順位・trusted_proxies 設定のスペックを追加
- `bundle exec rspec`: 56 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)