### PR TITLE
feat(backend): Sentryによるエラー監視を導入

### DIFF
--- a/backend/.kamal/secrets
+++ b/backend/.kamal/secrets
@@ -3,3 +3,4 @@ RAILS_MASTER_KEY=$(gcloud secrets versions access latest --secret=RAILS_MASTER_K
 BACKEND_DATABASE_PASSWORD=$(gcloud secrets versions access latest --secret=BACKEND_DATABASE_PASSWORD)
 CLOUDFLARE_ORIGIN_CERT=$(gcloud secrets versions access latest --secret=CLOUDFLARE_ORIGIN_CERT)
 CLOUDFLARE_ORIGIN_KEY=$(gcloud secrets versions access latest --secret=CLOUDFLARE_ORIGIN_KEY)
+SENTRY_DSN=$(gcloud secrets versions access latest --secret=SENTRY_DSN)

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -63,3 +63,6 @@ group :test do
   gem "database_cleaner-active_record", "~> 2.1"
   gem "simplecov", require: false
 end
+
+gem "sentry-ruby", "~> 6.6"
+gem "sentry-rails", "~> 6.6"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -341,6 +341,13 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
+    sentry-rails (6.6.2)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.6.2)
+    sentry-ruby (6.6.2)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
     signet (0.21.0)
@@ -411,6 +418,8 @@ DEPENDENCIES
   rails (~> 8.0.2)
   rspec-rails (~> 6.1)
   rubocop-rails-omakase
+  sentry-rails (~> 6.6)
+  sentry-ruby (~> 6.6)
   shoulda-matchers (~> 6.0)
   simplecov
   thruster

--- a/backend/config/deploy.yml
+++ b/backend/config/deploy.yml
@@ -26,6 +26,7 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - BACKEND_DATABASE_PASSWORD
+    - SENTRY_DSN
   clear:
     GOOGLE_CLIENT_ID: "432477473655-2ovs5abgvf6cu6ke9gli7b5phgi0je4u.apps.googleusercontent.com"
     # Neon (single DB). Direct endpoint (no -pooler) so Rails prepared statements work.

--- a/backend/config/initializers/sentry.rb
+++ b/backend/config/initializers/sentry.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# エラー監視（Sentry）。SENTRY_DSN が未設定の環境では何も送信しない。
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.enabled_environments = %w[production]
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
+
+  # 個人情報（IPアドレス・リクエストボディ等）は送らない
+  config.send_default_pii = false
+
+  # パフォーマンストレースは全体の10%をサンプリング
+  config.traces_sample_rate = 0.1
+end


### PR DESCRIPTION
## 概要
バックエンドにエラー監視（Sentry）を導入します。現状 Crashlytics は Android アプリ側のみで、Rails 側の本番エラーに気づく手段がありませんでした。

## 変更内容
- `sentry-ruby` / `sentry-rails` を追加
- `SENTRY_DSN` 未設定なら何も送信しない（開発・テスト環境は自動で無効）
- `send_default_pii = false`（IPアドレス等のPIIは送信しない）
- パフォーマンストレースは10%サンプリング
- `deploy.yml` の secret env と `.kamal/secrets` に `SENTRY_DSN` を配線

## マージ前に必要な作業（手動）
1. https://sentry.io で無料アカウント + Rails プロジェクトを作成し DSN を取得
2. GCP Secret Manager に登録:
   ```bash
   echo -n '<DSN>' | gcloud secrets create SENTRY_DSN --data-file=-
   ```
※ Secret 未登録のままマージするとデプロイ時に kamal の secrets 解決で失敗します

## テスト
`bundle exec rspec`: 53 examples, 0 failures / `Sentry.initialized?` => true

🤖 Generated with [Claude Code](https://claude.com/claude-code)