### PR TITLE
feat: プライバシーポリシーとアカウント削除案内ページを追加

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -12,8 +12,9 @@ Rails.application.configure do
   # Full error reports are disabled.
   config.consider_all_requests_local = false
 
-  # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  # public/ にはプライバシーポリシー等の更新されうるページを置いているため、
+  # キャッシュは短めにする（digestスタンプ付きアセットは存在しない）
+  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.hour.to_i}" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/backend/public/account-deletion.html
+++ b/backend/public/account-deletion.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>アカウント削除のご案内 | WorkoutRide</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      line-height: 1.8;
+      color: #333;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 24px 16px 64px;
+    }
+    h1 { font-size: 1.6rem; border-bottom: 2px solid #333; padding-bottom: 8px; }
+    h2 { font-size: 1.2rem; margin-top: 2em; }
+    ol li { margin-bottom: 0.5em; }
+    footer { margin-top: 3em; font-size: 0.85rem; color: #777; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #1a1a1a; color: #ddd; }
+      h1 { border-color: #ddd; }
+    }
+  </style>
+</head>
+<body>
+  <h1>WorkoutRide アカウント削除のご案内</h1>
+
+  <h2>アプリ内から削除する（推奨）</h2>
+  <ol>
+    <li>WorkoutRide アプリを開く</li>
+    <li>「設定」タブを開く</li>
+    <li>「アカウント」セクションの「アカウント削除」をタップ</li>
+    <li>確認ダイアログに「削除」と入力して「完全に削除する」をタップ</li>
+  </ol>
+  <p>削除は即時に実行され、取り消すことはできません。</p>
+
+  <h2>アプリを利用できない場合</h2>
+  <p>
+    端末の紛失などでアプリから削除できない場合は、<strong>ログインに使用したGoogleアカウントのメールアドレスから</strong>、以下の宛先に「アカウント削除希望」と記載してご連絡ください。本人確認のうえ、30日以内に削除します。
+  </p>
+  <p>メール: oh.naoki0819@gmail.com</p>
+
+  <h2>削除されるデータ</h2>
+  <ul>
+    <li>アカウント情報（Googleアカウントの識別子）</li>
+    <li>ワークアウト記録（実施日時・時間・パワー・ケイデンス等の全履歴）</li>
+    <li>体重・FTPの設定値と履歴</li>
+    <li>認証トークン（ログインセッション）</li>
+  </ul>
+  <p>
+    上記はすべて完全に削除され、保持されるデータはありません。なお、Firebase Crashlytics に送信済みのクラッシュ情報は個人を特定しない形式のため削除対象に含まれません（90日で自動削除されます）。
+  </p>
+
+  <footer>
+    <a href="/privacy.html">プライバシーポリシー</a><br>
+    WorkoutRide 開発者
+  </footer>
+</body>
+</html>

--- a/backend/public/privacy.html
+++ b/backend/public/privacy.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>プライバシーポリシー | WorkoutRide</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      line-height: 1.8;
+      color: #333;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 24px 16px 64px;
+    }
+    h1 { font-size: 1.6rem; border-bottom: 2px solid #333; padding-bottom: 8px; }
+    h2 { font-size: 1.2rem; margin-top: 2em; }
+    table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+    th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: left; font-size: 0.95rem; }
+    th { background: #f5f5f5; }
+    footer { margin-top: 3em; font-size: 0.85rem; color: #777; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #1a1a1a; color: #ddd; }
+      h1 { border-color: #ddd; }
+      th { background: #2a2a2a; }
+      th, td { border-color: #444; }
+    }
+  </style>
+</head>
+<body>
+  <h1>WorkoutRide プライバシーポリシー</h1>
+  <p>
+    WorkoutRide（以下「本アプリ」）の開発者（以下「当方」）は、本アプリにおける利用者の情報の取り扱いについて、以下のとおりプライバシーポリシーを定めます。
+  </p>
+
+  <h2>1. 収集する情報</h2>
+  <p>本アプリは、サービスの提供に必要な範囲で以下の情報を収集します。</p>
+  <table>
+    <tr><th>情報</th><th>取得方法</th><th>利用目的</th></tr>
+    <tr>
+      <td>Googleアカウントの識別子（ユーザーID）</td>
+      <td>Googleログイン時</td>
+      <td>アカウントの識別・認証</td>
+    </tr>
+    <tr>
+      <td>体重・FTP（機能的作業しきい値パワー）</td>
+      <td>利用者による入力</td>
+      <td>トレーニング強度・消費カロリー等の算出</td>
+    </tr>
+    <tr>
+      <td>ワークアウト記録（実施日時・時間・パワー・ケイデンス等）</td>
+      <td>ワークアウト実施時にBluetooth接続機器から取得</td>
+      <td>トレーニング履歴の保存・表示</td>
+    </tr>
+    <tr>
+      <td>クラッシュ情報・端末情報</td>
+      <td>アプリの動作時に自動収集</td>
+      <td>不具合の把握・品質改善</td>
+    </tr>
+  </table>
+  <p>本アプリは、氏名・メールアドレス・位置情報を収集しません。</p>
+
+  <h2>2. 情報の保存</h2>
+  <p>
+    収集した情報は、当方が管理する米国リージョンのサーバーおよびデータベースに保存されます。通信はすべてTLSにより暗号化されます。
+  </p>
+
+  <h2>3. 第三者サービスの利用</h2>
+  <p>本アプリは以下の第三者サービスを利用しており、各サービスのプライバシーポリシーが適用されます。</p>
+  <ul>
+    <li><a href="https://policies.google.com/privacy">Google（Googleログイン）</a></li>
+    <li><a href="https://firebase.google.com/support/privacy">Firebase Crashlytics（クラッシュレポート）</a></li>
+    <li><a href="https://sentry.io/privacy/">Sentry（サーバーエラー監視）</a></li>
+  </ul>
+
+  <h2>4. 第三者への提供</h2>
+  <p>
+    当方は、法令に基づく場合を除き、利用者の同意なく個人情報を第三者に提供しません。
+  </p>
+
+  <h2>5. データの削除</h2>
+  <p>
+    利用者は、アプリ内の「設定 &gt; アカウント &gt; アカウント削除」から、アカウントおよびすべての関連データ（ワークアウト記録・体重・FTP等）をいつでも完全に削除できます。
+    アプリを利用できない場合の削除手順は<a href="/account-deletion.html">アカウント削除のご案内</a>をご覧ください。
+  </p>
+
+  <h2>6. ポリシーの変更</h2>
+  <p>
+    本ポリシーの内容は、必要に応じて変更することがあります。重要な変更がある場合は、本ページにて告知します。
+  </p>
+
+  <h2>7. お問い合わせ</h2>
+  <p>
+    本ポリシーに関するお問い合わせは、以下の連絡先までお願いします。<br>
+    メール: oh.naoki0819@gmail.com
+  </p>
+
+  <footer>
+    制定日: 2026年7月12日<br>
+    WorkoutRide 開発者
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## 概要
ストア公開に必須の2ページを `backend/public/` に追加します。Rails は本番でも `public/` を静的配信するため、デプロイ済みの `workoutride.ohnaoki.app` でそのまま公開されます（追加インフラ不要）。

## 追加ページ
- **https://workoutride.ohnaoki.app/privacy.html** — プライバシーポリシー
  - 収集情報（Google UID・体重・FTP・ワークアウト記録・クラッシュ情報）と利用目的
  - 保存先（米国リージョン）・第三者サービス（Google / Crashlytics / Sentry）
  - アプリ内削除手順への導線
- **https://workoutride.ohnaoki.app/account-deletion.html** — アカウント削除のご案内
  - アプリ内削除手順（PR #79 のUIに対応）+ メールでの削除依頼（30日以内）
  - Google Play の「アカウント削除」ポリシーで要求されるWeb URLとして使用

## あわせて変更
- `public/` の cache-control を1年→1時間に短縮（ポリシー改定が反映されるように。digest付きアセットは存在しないため影響なし）

## 使い方（マージ後）
- Play Console: 「アプリのコンテンツ > プライバシーポリシー」に privacy.html のURLを登録
- Play Console: 「データセーフティ > アカウント削除」に account-deletion.html のURLを登録
- GCP OAuth同意画面: プライバシーポリシーURLに privacy.html を登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)