### PR TITLE
ci: mainのDebug APKビルド失敗を修正（debug flavor対応）

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -27,9 +27,10 @@ jobs:
         with:
           api-base-url: ${{ secrets.API_BASE_URL }}
 
-      - name: Place google-services.json
+      - name: Place google-services.json (debug)
         run: |
-          echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > android/app/google-services.json
+          mkdir -p android/app/src/debug
+          echo "${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}" | base64 --decode --ignore-garbage > android/app/src/debug/google-services.json
 
       - name: Build APK (debug)
         run: flutter build apk --debug
@@ -37,7 +38,7 @@ jobs:
       - name: Upload debug APK to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
+          appId: ${{ secrets.FIREBASE_APP_ID_DEBUG }}
           token: ${{ secrets.FIREBASE_TOKEN }}
           file: frontend/build/app/outputs/flutter-apk/app-debug.apk
           releaseNotes: "Debug build ${{ github.sha }}"


### PR DESCRIPTION
## 概要
main への push で走る `Build Debug APK` が PR #77（debug/release flavor分離）以降失敗しています。

```
No matching client found for package name 'com.github.ohnaoki.workoutride.debug'
```

## 原因
`build-debug.yml` だけが flavor 分離前の `GOOGLE_SERVICES_JSON` secret（debugパッケージのクライアント未登録）を `android/app/` 直下に置く旧方式のままでした。手動実行の `release-app-distribution.yml` は対応済みで成功しています。

## 変更内容
`release-app-distribution.yml` の debug ビルドと同じ方式に統一:
- `GOOGLE_SERVICES_JSON_DEBUG` を `android/app/src/debug/` に配置（`--ignore-garbage` 付き）
- App Distribution のアップロード先を `FIREBASE_APP_ID_DEBUG` に変更

どちらの secret も登録済み（2026-06-25、成功実績あり）。マージ後、main への push で green になるはずです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)