### PR TITLE
ci: 本番デプロイの手動実行（workflow_dispatch）を追加

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,7 @@ name: Deploy to Production
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## 概要
複数PRの連続マージ時、kamalのデプロイロック競合で後続の Deploy to Production が失敗することがあります（本日 #79〜#85 の連続マージで発生）。最新mainを任意のタイミングで再デプロイできるよう `workflow_dispatch` を追加します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)