### PR TITLE
feat: UIをアプリアイコンのオレンジ基調に統一

### DIFF
--- a/frontend/lib/component/meter.dart
+++ b/frontend/lib/component/meter.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:workoutride/ui/theme/app_colors.dart';
 
 class Meter extends StatelessWidget {
   final int power;
@@ -61,7 +62,7 @@ class _MeterPainter extends CustomPainter {
 
     // ドーナツ形状を描画
     final Paint donutPaint = Paint()
-      ..color = const Color(0xFFDB4040)
+      ..color = AppColors.surfaceHigh
       ..style = PaintingStyle.fill;
     canvas.drawPath(finalPath, donutPaint);
 
@@ -143,7 +144,7 @@ class _MeterPainter extends CustomPainter {
 
     // 線を描画
     final Paint linePaint = Paint()
-      ..color = Colors.white
+      ..color = AppColors.brand
       ..strokeWidth = 6.0
       ..style = PaintingStyle.stroke;
 

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/ui/auth/auth_state_notifier.dart';
 import 'package:workoutride/ui/auth/login_screen.dart';
 import 'package:workoutride/ui/home/home_screen.dart';
+import 'package:workoutride/ui/theme/app_colors.dart';
 import 'package:workoutride/ui/workout/workout_screen.dart';
 import 'package:workoutride/ui/workout_detail/workout_detail_screen.dart';
 
@@ -38,7 +39,24 @@ class MyApp extends ConsumerWidget {
     return MaterialApp(
       title: 'WorkoutRide',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.brand,
+          primary: AppColors.brand,
+        ),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: AppColors.brand,
+          foregroundColor: Colors.white,
+          elevation: 0,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.brand,
+            foregroundColor: Colors.white,
+          ),
+        ),
+        progressIndicatorTheme: const ProgressIndicatorThemeData(
+          color: AppColors.brand,
+        ),
         useMaterial3: true,
       ),
       home: authState.when(

--- a/frontend/lib/ui/home/home_screen.dart
+++ b/frontend/lib/ui/home/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:workoutride/domain/model/workout/workout_summary.dart';
 import 'package:workoutride/ui/history/history_screen.dart';
 import 'package:workoutride/ui/settings/settings_screen.dart';
 import 'package:workoutride/ui/home/home_screen_state_notifier.dart';
+import 'package:workoutride/ui/theme/app_colors.dart';
 import 'package:workoutride/ui/workout_detail/workout_detail_screen.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -26,7 +27,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           _currentIndex == 0 ? 'Home' : '履歴',
           style: const TextStyle(color: Colors.white),
         ),
-        backgroundColor: Colors.black,
+        backgroundColor: AppColors.brand,
+        foregroundColor: Colors.white,
+        elevation: 0,
         centerTitle: true,
         actions: [
           IconButton(
@@ -42,7 +45,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
         ],
       ),
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.background,
       body: IndexedStack(
         index: _currentIndex,
         children: [
@@ -106,8 +109,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             _currentIndex = index;
           });
         },
-        backgroundColor: const Color(0xFF1C1C1C),
-        selectedItemColor: Colors.white,
+        backgroundColor: AppColors.surface,
+        selectedItemColor: AppColors.brand,
         unselectedItemColor: Colors.white54,
         items: const [
           BottomNavigationBarItem(
@@ -138,14 +141,27 @@ class SectionTitle extends StatelessWidget {
           horizontal: 16,
           vertical: 24,
         ),
-        child: Text(
-          title,
-          textAlign: TextAlign.left,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-          ),
+        child: Row(
+          children: [
+            Container(
+              width: 4,
+              height: 24,
+              decoration: BoxDecoration(
+                color: AppColors.brand,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Text(
+              title,
+              textAlign: TextAlign.left,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -190,6 +206,7 @@ class WorkoutItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
+      borderRadius: BorderRadius.circular(10),
       onTap: () {
         Navigator.push(
           context,
@@ -200,38 +217,52 @@ class WorkoutItem extends StatelessWidget {
           ),
         );
       },
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            summary.name,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(10),
+          border: const Border(
+            left: BorderSide(color: AppColors.brand, width: 4),
+          ),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              summary.name,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
             ),
-          ),
-          const SizedBox(height: 4),
-          Row(
-            children: [
-              Text(
-                '合計時間: ${_formatDuration(summary.totalDuration)}',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Icon(Icons.schedule, size: 15, color: AppColors.brand),
+                const SizedBox(width: 4),
+                Text(
+                  _formatDuration(summary.totalDuration),
+                  style: const TextStyle(
+                    color: Colors.white70,
+                    fontSize: 14,
+                  ),
                 ),
-              ),
-              const SizedBox(width: 16),
-              Text(
-                'カテゴリ: ${summary.category}',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
+                const SizedBox(width: 16),
+                const Icon(Icons.local_fire_department, size: 15, color: AppColors.brand),
+                const SizedBox(width: 4),
+                Text(
+                  summary.category,
+                  style: const TextStyle(
+                    color: Colors.white70,
+                    fontSize: 14,
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -248,7 +279,7 @@ class BleConnectionStatus extends ConsumerWidget {
       margin: const EdgeInsets.all(16),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: const Color(0xFF2C2C2C),
+        color: AppColors.surfaceHigh,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
           color: uiState.isBleConnected ? Colors.green : Colors.orange,
@@ -264,7 +295,7 @@ class BleConnectionStatus extends ConsumerWidget {
                 ? Icons.bluetooth_connected
                 : Icons.bluetooth_disabled,
             color: uiState.isConnectingBle
-              ? Colors.blue
+              ? AppColors.brand
               : uiState.isBleConnected
                 ? Colors.green
                 : Colors.orange,
@@ -316,7 +347,7 @@ class BleConnectionStatus extends ConsumerWidget {
               icon: const Icon(Icons.refresh, size: 16),
               label: const Text('再接続'),
               style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blue,
+                backgroundColor: AppColors.brand,
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                 textStyle: const TextStyle(fontSize: 13),

--- a/frontend/lib/ui/theme/app_colors.dart
+++ b/frontend/lib/ui/theme/app_colors.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// アプリのブランドカラー（アイコンのオレンジに合わせている）
+class AppColors {
+  const AppColors._();
+
+  /// メインのブランドカラー
+  static const Color brand = Color(0xFFFF6A13);
+
+  /// ブランドカラーの濃いトーン（グラデーションやAppBarの下地）
+  static const Color brandDark = Color(0xFFE04E00);
+
+  /// 画面全体の背景
+  static const Color background = Color(0xFF121212);
+
+  /// カードなどの一段明るい面
+  static const Color surface = Color(0xFF1E1E1E);
+
+  /// さらに明るい面（ボトムナビなど）
+  static const Color surfaceHigh = Color(0xFF2C2C2C);
+}

--- a/frontend/lib/ui/workout/workout_screen.dart
+++ b/frontend/lib/ui/workout/workout_screen.dart
@@ -5,6 +5,7 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:workoutride/component/meter.dart';
 import 'package:workoutride/ui/workout/developer_menu.dart';
 import 'package:workoutride/ui/workout/workout_screen_state_notifier.dart';
+import 'package:workoutride/ui/theme/app_colors.dart';
 
 class WorkoutScreen extends ConsumerStatefulWidget {
   final int workoutId;
@@ -80,9 +81,10 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
     return PopScope(
       canPop: false,
       child: Scaffold(
-        backgroundColor: Colors.black,
+        backgroundColor: AppColors.background,
         appBar: AppBar(
           backgroundColor: Colors.transparent,
+          elevation: 0,
           actions: [
             if (kDebugMode)
               IconButton(
@@ -139,7 +141,7 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
                               child: Container(
                                 padding: const EdgeInsets.all(32.0),
                                 decoration: BoxDecoration(
-                                  color: Colors.black.withValues(alpha: 0.8),
+                                  color: Colors.black.withValues(alpha: 0.94),
                                   borderRadius: BorderRadius.circular(16.0),
                                 ),
                                 child: Column(
@@ -148,7 +150,7 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
                                     Text(
                                       '${uiState.countdownSeconds}',
                                       style: const TextStyle(
-                                        color: Colors.white,
+                                        color: AppColors.brand,
                                         fontSize: 72,
                                         fontWeight: FontWeight.bold,
                                       ),
@@ -300,7 +302,7 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
         width: 60,
         height: 60,
         decoration: BoxDecoration(
-          color: isPaused ? Colors.green : Colors.orange,
+          color: isPaused ? Colors.green : AppColors.brand,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Icon(
@@ -399,14 +401,21 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       width: double.infinity,
-      color: const Color(0xFF333333),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isActive ? AppColors.brand : Colors.transparent,
+          width: 2,
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
       child: Column(
         children: [
           // パワー表示部分
           Container(
             width: double.infinity,
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            color: const Color(0xFF333333),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -420,16 +429,16 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
                 const SizedBox(width: 8),
                 Text(
                   '$power',
-                  style: const TextStyle(
-                    color: Colors.white,
+                  style: TextStyle(
+                    color: isActive ? AppColors.brand : Colors.white,
                     fontSize: 48,
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                const Text(
+                Text(
                   'w',
                   style: TextStyle(
-                    color: Colors.white,
+                    color: isActive ? AppColors.brand : Colors.white,
                     fontSize: 24,
                     fontWeight: FontWeight.bold,
                   ),
@@ -447,9 +456,11 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
                   LinearProgressIndicator(
                     value: progress,
                     minHeight: 40,
-                    backgroundColor: Colors.grey[800],
+                    backgroundColor: AppColors.surfaceHigh,
                     valueColor: AlwaysStoppedAnimation<Color>(
-                      isActive ? const Color(0xFF51DB40) : const Color(0xFF333333),
+                      isActive
+                        ? AppColors.brand
+                        : AppColors.brand.withValues(alpha: 0.25),
                     ),
                   ),
                   Container(

--- a/frontend/lib/ui/workout_detail/workout_detail_screen.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/ui/workout_detail/workout_detail_screen_state_notifier.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/ui/workout/workout_screen.dart';
+import 'package:workoutride/ui/theme/app_colors.dart';
 
 class WorkoutDetailScreen extends ConsumerWidget {
   final int workoutId;
@@ -15,13 +16,15 @@ class WorkoutDetailScreen extends ConsumerWidget {
     final uiState = ref.watch(workoutDetailScreenStateNotifierProvider(workoutId));
     
     return Scaffold(
-      backgroundColor: const Color(0xFF1E1E1E),
+      backgroundColor: AppColors.background,
       appBar: AppBar(
         title: const Text(
           'ワークアウト詳細',
           style: TextStyle(color: Colors.white),
         ),
-        backgroundColor: const Color(0xFF2D2D2D),
+        backgroundColor: AppColors.brand,
+        foregroundColor: Colors.white,
+        elevation: 0,
         iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: Padding(
@@ -109,7 +112,7 @@ class WorkoutDetailBody extends StatelessWidget {
                         );
                       },
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.green,
+                        backgroundColor: AppColors.brand,
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
## 概要
新アプリアイコン（オレンジ + Wレターマーク、#88）に合わせて、アプリ全体のアクセントカラーをブランドオレンジ `#FF6A13` に統一しました。

## 変更内容
- `lib/ui/theme/app_colors.dart` を追加し、散らばっていた色リテラルを集約
- `ThemeData` に `appBarTheme` / `elevatedButtonTheme` / `progressIndicatorTheme` を追加。今後追加する画面も自動でブランドカラーに追従する
- **ホーム**: AppBarをオレンジ化 / ワークアウトカードを面 + 左端オレンジライン / 見出しにアクセントバー / 時間・カテゴリにアイコン追加
- **ワークアウト詳細**: AppBar と「ワークアウト開始」ボタンをオレンジ化（開始ボタンは緑→オレンジ）
- **ワークアウト実行**: 実行中ブロックをオレンジ枠 + オレンジのワット表示 / 進捗バーを緑→オレンジ（完了済みは薄オレンジ）/ カウントダウンオーバーレイの視認性改善
- **メーター**: 土台の赤(`#DB4040`)がオレンジと衝突していたためニュートラルなダークに変更。現在パワーの指針を白→オレンジ

## 意図的に変えていないもの
完了/中断、接続済み/未接続、エラーを示す緑・オレンジ・赤は**意味色**として維持しています。メーターのターゲットゾーンの緑弧も同様です。

## 確認
- `flutter analyze` エラーなし（既存の info のみ）
- Android エミュレータの release ビルドで、ホーム / ワークアウト詳細 / ワークアウト実行（カウントダウン・実行中）の表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aCYBsaVneKbeD3Jnp6JF5