### PR TITLE
fix: ケイデンスが一瞬だけ落ちる不具合を修正

### DIFF
--- a/frontend/lib/domain/usecase/get_power_meter_data_use_case.dart
+++ b/frontend/lib/domain/usecase/get_power_meter_data_use_case.dart
@@ -4,10 +4,28 @@ import 'package:workoutride/domain/model/power_meter_data.dart';
 class GetPowerMeterDataUseCase {
   final PowerMeterDataSource _powerMeterDataSource;
 
+  /// 時刻取得関数（テストから差し替え可能）
+  final DateTime Function() _now;
+
+  /// 新しいクランクイベントがこの時間来なければ停止とみなしてケイデンスを0にする
+  static const Duration _cadenceStaleThreshold = Duration(seconds: 3);
+
   int lastCrankRevolutions = 0;
   int lastCrankEventTime = 0;
 
-  GetPowerMeterDataUseCase(this._powerMeterDataSource);
+  /// クランクデータを一度でも受信したか（初回パケットの誤差分計算を防ぐ）
+  bool _hasPreviousCrankData = false;
+
+  /// 直近に算出したケイデンス（新しいクランクイベントが無い通知で保持する）
+  int _lastCadence = 0;
+
+  /// 最後に「新しいクランクイベント」を観測した実時刻
+  DateTime? _lastCrankEventAt;
+
+  GetPowerMeterDataUseCase(
+    this._powerMeterDataSource, {
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
 
   Stream<PowerMeterData> call() {
     return _powerMeterDataSource.getRawData().map((value) {
@@ -17,7 +35,7 @@ class GetPowerMeterDataUseCase {
 
   PowerMeterData processData(List<int> value) {
     if (value.isEmpty || value.length < 4) {  // 最低でもフラグとパワーが必要
-      return const PowerMeterData(power: 0, cadence: 0);
+      return PowerMeterData(power: 0, cadence: _lastCadence);
     }
 
     // Flags の最初の 2 バイトを取得
@@ -34,23 +52,49 @@ class GetPowerMeterDataUseCase {
     }
 
     // Crank Revolution Data (任意, Flag の Bit 5 が立っている場合)
-    double crankRpm = 0;
+    double crankRpm = _lastCadence.toDouble();
     if ((flags & 0x020) != 0 && value.length >= index + 4) {
       int cumulativeCrankRevolutions = (value[index + 1] << 8) | value[index];
       index += 2;
       int currentCrankEventTime = (value[index + 1] << 8) | value[index];
-      int timeDiff = currentCrankEventTime - lastCrankEventTime;
-      int revDiff = cumulativeCrankRevolutions - lastCrankRevolutions;
-      if (timeDiff != 0 && revDiff != 0) {
-        crankRpm = (revDiff * 60 / (timeDiff / 1024));
+
+      // currentCrankEventTime / cumulativeCrankRevolutions は 16bit 値で
+      // ラップアラウンドするため、差分は 16bit マスクを取る
+      // （currentCrankEventTime は 1/1024 秒単位で約 64 秒ごとに一周する）
+      int timeDiff = (currentCrankEventTime - lastCrankEventTime) & 0xFFFF;
+      int revDiff = (cumulativeCrankRevolutions - lastCrankRevolutions) & 0xFFFF;
+
+      final now = _now();
+      if (!_hasPreviousCrankData) {
+        // 初回はまだ差分を計算できない（累積値の基準が不明なため）
+        crankRpm = 0;
+      } else if (revDiff > 0 && timeDiff > 0) {
+        // 新しいクランクイベントあり → ケイデンスを算出
+        crankRpm = revDiff * 60 / (timeDiff / 1024);
+        _lastCrankEventAt = now;
+      } else {
+        // 新しいクランクイベントが無い通知
+        // （デバイスがクランク周期より速く notify する等で頻発する）
+        if (_lastCrankEventAt == null ||
+            now.difference(_lastCrankEventAt!) >= _cadenceStaleThreshold) {
+          // 一定時間イベントが無ければ停止とみなす
+          crankRpm = 0;
+        } else {
+          // 直前のケイデンスを保持し、平均値のディップ（一瞬だけ低下）を防ぐ
+          crankRpm = _lastCadence.toDouble();
+        }
       }
+
       lastCrankEventTime = currentCrankEventTime;
       lastCrankRevolutions = cumulativeCrankRevolutions;
+      _hasPreviousCrankData = true;
     }
+
+    _lastCadence = crankRpm.toInt();
 
     return PowerMeterData(
       power: instantaneousPower,
-      cadence: crankRpm.toInt(),
+      cadence: _lastCadence,
     );
   }
 }

--- a/frontend/test/usecase/get_power_meter_data_use_case_test.dart
+++ b/frontend/test/usecase/get_power_meter_data_use_case_test.dart
@@ -153,5 +153,93 @@ void main() {
         expect(() => useCase.call(), throwsException);
       });
     });
+
+    // ケイデンスが一瞬だけ落ちる不具合の回帰テスト
+    group('Cadence stability', () {
+      // Crank Revolution Data 付きのパケットを生成するヘルパー
+      List<int> crankPacket({
+        required int power,
+        required int revs,
+        required int time,
+      }) =>
+          [
+            0x20, 0x00, // flags: Crank Revolution Data あり
+            power & 0xFF, (power >> 8) & 0xFF,
+            revs & 0xFF, (revs >> 8) & 0xFF,
+            time & 0xFF, (time >> 8) & 0xFF,
+          ];
+
+      test('新しいクランクイベントが無い通知では直前のケイデンスを保持する', () {
+        // Arrange
+        var clock = DateTime(2026, 1, 1);
+        final useCase = GetPowerMeterDataUseCase(
+          mockPowerMeterDataSource,
+          now: () => clock,
+        );
+
+        // Act
+        // 基準パケット（初回は差分を計算できないので0）
+        useCase.processData(crankPacket(power: 200, revs: 0, time: 0));
+        // 3回転 / 2秒 → 90rpm
+        final r1 = useCase.processData(crankPacket(power: 200, revs: 3, time: 2048));
+        // 同じクランクデータ（新イベントなし）が1秒後に届く
+        clock = clock.add(const Duration(seconds: 1));
+        final r2 = useCase.processData(crankPacket(power: 200, revs: 3, time: 2048));
+
+        // Assert
+        expect(r1.cadence, equals(90));
+        // 0 に落とさず 90 を保持する（平均のディップ＝一瞬60rpm等を防ぐ）
+        expect(r2.cadence, equals(90));
+      });
+
+      test('一定時間クランクイベントが無ければケイデンスは0になる', () {
+        // Arrange
+        var clock = DateTime(2026, 1, 1);
+        final useCase = GetPowerMeterDataUseCase(
+          mockPowerMeterDataSource,
+          now: () => clock,
+        );
+
+        // Act
+        useCase.processData(crankPacket(power: 200, revs: 0, time: 0));
+        final r1 = useCase.processData(crankPacket(power: 200, revs: 3, time: 2048));
+        // しきい値(3秒)を超えて新イベントが来ない → 停止とみなす
+        clock = clock.add(const Duration(seconds: 4));
+        final r2 = useCase.processData(crankPacket(power: 200, revs: 3, time: 2048));
+
+        // Assert
+        expect(r1.cadence, equals(90));
+        expect(r2.cadence, equals(0));
+      });
+
+      test('クランクイベント時刻の16bitラップアラウンドを跨いでも正しく計算する', () {
+        // Arrange
+        final useCase = GetPowerMeterDataUseCase(mockPowerMeterDataSource);
+
+        // Act
+        // 基準: time=65000 (残り 536 でラップ)
+        useCase.processData(crankPacket(power: 200, revs: 100, time: 65000));
+        // 65000 + 2048 = 67048 → 65536 で一周し 1512
+        final result = useCase.processData(crankPacket(power: 200, revs: 103, time: 1512));
+
+        // Assert
+        // 3回転 / 2秒 = 90rpm（マスクしないと timeDiff が巨大な負数になり破綻する）
+        expect(result.cadence, equals(90));
+      });
+
+      test('累積回転数の16bitラップアラウンドを跨いでも正しく計算する', () {
+        // Arrange
+        final useCase = GetPowerMeterDataUseCase(mockPowerMeterDataSource);
+
+        // Act
+        // 基準: revs=65535
+        useCase.processData(crankPacket(power: 200, revs: 65535, time: 0));
+        // 65535 + 3 = 65538 → 一周して 2
+        final result = useCase.processData(crankPacket(power: 200, revs: 2, time: 2048));
+
+        // Assert
+        expect(result.cadence, equals(90));
+      });
+    });
   });
 }


### PR DESCRIPTION
## 症状
90rpm程度で回しているのに、ケイデンス表示が一瞬だけ60rpm等へ落ちる。

## 原因
`GetPowerMeterDataUseCase.processData`（BLE Cycling Power 2A63 のパース）に2つの問題がありました。

### 1. 新しいクランクイベントが無い通知で `0` を出していた（主原因）
`revDiff == 0`（前回から新しいクランク回転が完了していない通知）のときケイデンスを **0** として出力していました。BLEデバイスはクランク周期より速く notify することがあり、この0が頻発します。

これが `GetCalculatedPowerMeterDataUseCase` の**直近3秒平均**に混ざり、`{90, 90, 0} → 60` のディップを起こしていました。「一瞬60rpm」はこの計算そのものです。

### 2. 16bitラップアラウンド未処理（副次原因・約64秒周期）
`currentCrankEventTime`（1/1024秒単位・16bit）は約64秒ごとに一周します。差分をマスクしていなかったため、折り返し時に `timeDiff` が巨大な負数になり異常値を出していました。

## 対応
- 差分計算を `& 0xFFFF` でマスクし16bitラップアラウンドに対応
- 新イベントが無い通知では**直前のケイデンスを保持**。一定時間（3秒）新イベントが来なければ停止とみなして0にする
- 初回パケットは累積値の基準が不明なため差分計算せず0を返す（電源投入以降の累積値による初回の異常値も防止）
- テスト用に時刻取得関数（`now`）を注入可能にし、回帰テストを追加

## テスト
新規4件を追加、既存含め全パス・`flutter analyze` クリーン。
- 新イベント無し通知で直前ケイデンスを保持する
- 一定時間イベントが無ければ0になる
- クランクイベント時刻の16bitラップアラウンドを跨いでも正しく計算する
- 累積回転数の16bitラップアラウンドを跨いでも正しく計算する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aCYBsaVneKbeD3Jnp6JF5