### PR TITLE
refactor: 旧StateNotifier→codegen統一 + MockPattern domain移設 (Phase 1)

### DIFF
--- a/frontend/lib/data/power_meter_data_source.dart
+++ b/frontend/lib/data/power_meter_data_source.dart
@@ -1,4 +1,5 @@
 import 'package:workoutride/data/ble_connector.dart';
+import 'package:workoutride/domain/model/mock_pattern.dart';
 
 abstract class PowerMeterDataSource {
   Stream<List<int>> getRawData();
@@ -6,22 +7,17 @@ abstract class PowerMeterDataSource {
 
 class BlePowerMeterDataSource implements PowerMeterDataSource {
   final BleConnector _bleConnector;
-  
+
   BlePowerMeterDataSource(this._bleConnector);
-  
+
   @override
   Stream<List<int>> getRawData() => _bleConnector.notify("2A63");
 }
 
-enum MockPattern {
-  warmup(name: 'ウォームアップ'),
-  interval(name: 'インターバル'),
-  steady(name: 'ステディ'),
-  cooldown(name: 'クールダウン');
-
-  final String name;
-  const MockPattern({required this.name});
-
+/// MockPattern（ドメインの値）に対して、モックの生パワーメーターデータを
+/// 生成するロジックを与える data 層の extension。
+/// domain には識別子・表示名のみを置き、生成ロジックはここ（data）に閉じる。
+extension MockPatternGenerator on MockPattern {
   List<int> generateData(int count) {
     switch (this) {
       case MockPattern.warmup:
@@ -34,91 +30,93 @@ enum MockPattern {
         return _generateCooldownData(count);
     }
   }
+}
 
-  // ウォームアップパターン: 徐々にパワーが上昇
-  List<int> _generateWarmupData(int count) {
-    // より滑らかな上昇カーブ（100Wから200Wまで3分かけて上昇）
-    final progress = (count % 180) / 180.0;  // 3分で1サイクル
-    final power = 100 + (100 * progress).toInt();
-    final cadence = count;  // 累積回転数として使用
-    return _createPowerMeterData(power, cadence);
+// ウォームアップパターン: 徐々にパワーが上昇
+List<int> _generateWarmupData(int count) {
+  // より滑らかな上昇カーブ（100Wから200Wまで3分かけて上昇）
+  final progress = (count % 180) / 180.0; // 3分で1サイクル
+  final power = 100 + (100 * progress).toInt();
+  final cadence = count; // 累積回転数として使用
+  return _createPowerMeterData(power, cadence);
+}
+
+// インターバルパターン: 高強度と低強度を繰り返す
+List<int> _generateIntervalData(int count) {
+  // 30秒間隔でのインターバル（より滑らかな遷移）
+  final cyclePosition = count % 30; // 30秒で1サイクル
+  final baseIntensity = count ~/ 30 % 2 == 0; // 30秒ごとに切り替え
+
+  int power;
+  if (cyclePosition < 5) {
+    // 5秒間の遷移時間
+    // 低強度から高強度、または高強度から低強度への遷移
+    final transitionProgress = cyclePosition / 5.0;
+    power = baseIntensity
+        ? (150 + (100 * transitionProgress)).toInt() // 150W → 250W
+        : (250 - (100 * transitionProgress)).toInt(); // 250W → 150W
+  } else {
+    // 一定強度の維持
+    power = baseIntensity ? 250 : 150;
   }
 
-  // インターバルパターン: 高強度と低強度を繰り返す
-  List<int> _generateIntervalData(int count) {
-    // 30秒間隔でのインターバル（より滑らかな遷移）
-    final cyclePosition = count % 30;  // 30秒で1サイクル
-    final baseIntensity = count ~/ 30 % 2 == 0;  // 30秒ごとに切り替え
-    
-    int power;
-    if (cyclePosition < 5) {  // 5秒間の遷移時間
-      // 低強度から高強度、または高強度から低強度への遷移
-      final transitionProgress = cyclePosition / 5.0;
-      power = baseIntensity
-          ? (150 + (100 * transitionProgress)).toInt()  // 150W → 250W
-          : (250 - (100 * transitionProgress)).toInt(); // 250W → 150W
-    } else {
-      // 一定強度の維持
-      power = baseIntensity ? 250 : 150;
-    }
-    
-    final cadence = count;  // 累積回転数として使用
-    return _createPowerMeterData(power, cadence);
-  }
+  final cadence = count; // 累積回転数として使用
+  return _createPowerMeterData(power, cadence);
+}
 
-  // ステディパターン: 一定のパワーを維持（わずかな変動あり）
-  List<int> _generateSteadyData(int count) {
-    // 180W±10Wの範囲でわずかに変動
-    final variation = (count % 10) - 5;  // -5から+5の変動
-    final power = 180 + variation;
-    final cadence = count;  // 累積回転数として使用
-    return _createPowerMeterData(power, cadence);
-  }
+// ステディパターン: 一定のパワーを維持（わずかな変動あり）
+List<int> _generateSteadyData(int count) {
+  // 180W±10Wの範囲でわずかに変動
+  final variation = (count % 10) - 5; // -5から+5の変動
+  final power = 180 + variation;
+  final cadence = count; // 累積回転数として使用
+  return _createPowerMeterData(power, cadence);
+}
 
-  // クールダウンパターン: 徐々にパワーが低下
-  List<int> _generateCooldownData(int count) {
-    // より滑らかな下降カーブ（200Wから100Wまで3分かけて下降）
-    final progress = (count % 180) / 180.0;  // 3分で1サイクル
-    final power = 200 - (100 * progress).toInt();
-    final cadence = count;  // 累積回転数として使用
-    return _createPowerMeterData(power, cadence);
-  }
+// クールダウンパターン: 徐々にパワーが低下
+List<int> _generateCooldownData(int count) {
+  // より滑らかな下降カーブ（200Wから100Wまで3分かけて下降）
+  final progress = (count % 180) / 180.0; // 3分で1サイクル
+  final power = 200 - (100 * progress).toInt();
+  final cadence = count; // 累積回転数として使用
+  return _createPowerMeterData(power, cadence);
+}
 
-  // BLEデータフォーマットに合わせてデータを生成
-  List<int> _createPowerMeterData(int power, int cadence) {
-    // フラグの設定（Crank Revolution Dataを含むことを示す）
-    final flags = 0x020;  // Bit 5 を立てる（クランク回転データあり）
-    
-    // パワーを16ビットの整数として表現
-    final powerBytes = power.toUnsigned(16);
-    
-    // クランク回転データ
-    final cumulativeCrankRevolutions = cadence;  // 累積回転数をそのまま使用
-    final currentCrankEventTime = (cadence * 1024) % 65536;  // 時間も累積的に増加（65536でラップアラウンド）
-    
-    // BLEデータフォーマットに合わせてバイト配列を作成
-    return [
-      flags & 0xFF,           // フラグ（下位バイト）
-      (flags >> 8) & 0xFF,   // フラグ（上位バイト）
-      powerBytes & 0xFF,     // パワー（下位バイト）
-      (powerBytes >> 8) & 0xFF,  // パワー（上位バイト）
-      cumulativeCrankRevolutions & 0xFF,  // クランク回転数（下位バイト）
-      (cumulativeCrankRevolutions >> 8) & 0xFF,  // クランク回転数（上位バイト）
-      currentCrankEventTime & 0xFF,  // イベント時間（下位バイト）
-      (currentCrankEventTime >> 8) & 0xFF,  // イベント時間（上位バイト）
-    ];
-  }
+// BLEデータフォーマットに合わせてデータを生成
+List<int> _createPowerMeterData(int power, int cadence) {
+  // フラグの設定（Crank Revolution Dataを含むことを示す）
+  const flags = 0x020; // Bit 5 を立てる（クランク回転データあり）
+
+  // パワーを16ビットの整数として表現
+  final powerBytes = power.toUnsigned(16);
+
+  // クランク回転データ
+  final cumulativeCrankRevolutions = cadence; // 累積回転数をそのまま使用
+  final currentCrankEventTime =
+      (cadence * 1024) % 65536; // 時間も累積的に増加（65536でラップアラウンド）
+
+  // BLEデータフォーマットに合わせてバイト配列を作成
+  return [
+    flags & 0xFF, // フラグ（下位バイト）
+    (flags >> 8) & 0xFF, // フラグ（上位バイト）
+    powerBytes & 0xFF, // パワー（下位バイト）
+    (powerBytes >> 8) & 0xFF, // パワー（上位バイト）
+    cumulativeCrankRevolutions & 0xFF, // クランク回転数（下位バイト）
+    (cumulativeCrankRevolutions >> 8) & 0xFF, // クランク回転数（上位バイト）
+    currentCrankEventTime & 0xFF, // イベント時間（下位バイト）
+    (currentCrankEventTime >> 8) & 0xFF, // イベント時間（上位バイト）
+  ];
 }
 
 class MockPowerMeterDataSource implements PowerMeterDataSource {
   final MockPattern pattern;
-  
+
   MockPowerMeterDataSource(this.pattern);
-  
+
   @override
   Stream<List<int>> getRawData() {
     return Stream.periodic(const Duration(seconds: 1), (count) {
       return pattern.generateData(count);
     });
   }
-} 
+}

--- a/frontend/lib/di/providers.dart
+++ b/frontend/lib/di/providers.dart
@@ -23,6 +23,7 @@ import 'package:workoutride/domain/usecase/workout/get_workout_summary_use_case.
 import 'package:workoutride/domain/usecase/workout/save_workout_result_use_case.dart';
 import 'package:workoutride/data/ble_connector.dart';
 import 'package:workoutride/data/power_meter_data_source.dart';
+import 'package:workoutride/domain/model/mock_pattern.dart';
 import 'package:workoutride/domain/usecase/workout/manage_workout_use_case.dart';
 import 'package:workoutride/domain/usecase/get_calculated_power_meter_data_usecase.dart';
 import 'package:workoutride/domain/service/power_zone_analyzer.dart';
@@ -57,7 +58,8 @@ FlutterSecureStorage secureStorage(Ref ref) {
 GoogleSignIn googleSignIn(Ref ref) {
   return GoogleSignIn(
     scopes: ['email', 'profile'],
-    serverClientId: '432477473655-2ovs5abgvf6cu6ke9gli7b5phgi0je4u.apps.googleusercontent.com',
+    serverClientId:
+        '432477473655-2ovs5abgvf6cu6ke9gli7b5phgi0je4u.apps.googleusercontent.com',
   );
 }
 
@@ -75,49 +77,42 @@ AuthRepository authRepository(Ref ref) {
   );
 }
 
-class MockModeStateNotifier extends StateNotifier<bool> {
-  final SharedPreferences _sharedPreferences;
-  
-  MockModeStateNotifier(this._sharedPreferences) 
-    : super(_sharedPreferences.getBool(_mockModeKey) ?? false);
-
-  bool get value => state;
+/// モックモードの ON/OFF。SharedPreferences に永続化する。
+@riverpod
+class MockMode extends _$MockMode {
+  @override
+  bool build() {
+    return ref.watch(sharedPreferencesProvider).getBool(_mockModeKey) ?? false;
+  }
 
   void toggle() {
-    state = !state;
-    _sharedPreferences.setBool(_mockModeKey, state);
+    final next = !state;
+    ref.read(sharedPreferencesProvider).setBool(_mockModeKey, next);
+    state = next;
   }
 }
 
-class MockPatternStateNotifier extends StateNotifier<MockPattern> {
-  final SharedPreferences _sharedPreferences;
-  
-  MockPatternStateNotifier(this._sharedPreferences) 
-    : super(_getInitialPattern(_sharedPreferences));
-
-  static MockPattern _getInitialPattern(SharedPreferences prefs) {
-    final savedPattern = prefs.getString(_mockPatternKey);
-    return savedPattern != null 
-      ? MockPattern.values.firstWhere((p) => p.name == savedPattern)
-      : MockPattern.warmup;
+/// モックパワーデータのパターン選択。SharedPreferences に永続化する。
+@riverpod
+class MockPatternSelection extends _$MockPatternSelection {
+  @override
+  MockPattern build() {
+    final savedPattern =
+        ref.watch(sharedPreferencesProvider).getString(_mockPatternKey);
+    return savedPattern != null
+        ? MockPattern.values.firstWhere(
+            (p) => p.name == savedPattern,
+            orElse: () => MockPattern.warmup,
+          )
+        : MockPattern.warmup;
   }
-
-  MockPattern get value => state;
 
   void setPattern(MockPattern pattern) {
+    ref
+        .read(sharedPreferencesProvider)
+        .setString(_mockPatternKey, pattern.name);
     state = pattern;
-    _sharedPreferences.setString(_mockPatternKey, pattern.name);
   }
-}
-
-@riverpod
-MockModeStateNotifier mockModeStateNotifier(Ref ref) {
-  return MockModeStateNotifier(ref.read(sharedPreferencesProvider));
-}
-
-@riverpod
-MockPatternStateNotifier mockPatternStateNotifier(Ref ref) {
-  return MockPatternStateNotifier(ref.read(sharedPreferencesProvider));
 }
 
 // UseCaseプロバイダー
@@ -188,11 +183,11 @@ WorkoutRepository workoutRepository(Ref ref) {
 
 @riverpod
 PowerMeterDataSource powerMeterDataSource(Ref ref) {
-  final mockModeNotifier = ref.watch(mockModeStateNotifierProvider);
-  final mockPatternNotifier = ref.watch(mockPatternStateNotifierProvider);
-  
-  if (mockModeNotifier.value) {
-    return MockPowerMeterDataSource(mockPatternNotifier.value);
+  final isMockMode = ref.watch(mockModeProvider);
+  final mockPattern = ref.watch(mockPatternSelectionProvider);
+
+  if (isMockMode) {
+    return MockPowerMeterDataSource(mockPattern);
   } else {
     return BlePowerMeterDataSource(ref.read(bleConnectorProvider));
   }
@@ -210,12 +205,14 @@ UserProfileRepository userProfileRepository(Ref ref) {
 
 @riverpod
 GetUserProfileUseCase getUserProfileUseCase(Ref ref) {
-  return GetUserProfileUseCase(repository: ref.read(userProfileRepositoryProvider));
+  return GetUserProfileUseCase(
+      repository: ref.read(userProfileRepositoryProvider));
 }
 
 @riverpod
 SaveUserWeightUseCase saveUserWeightUseCase(Ref ref) {
-  return SaveUserWeightUseCase(repository: ref.read(userProfileRepositoryProvider));
+  return SaveUserWeightUseCase(
+      repository: ref.read(userProfileRepositoryProvider));
 }
 
 @riverpod
@@ -255,7 +252,8 @@ GetPowerMeterDataUseCase getPowerMeterDataUseCase(Ref ref) {
 
 @riverpod
 GetCalculatedPowerMeterDataUseCase getCalculatedPowerMeterDataUseCase(Ref ref) {
-  return GetCalculatedPowerMeterDataUseCase(ref.read(getPowerMeterDataUseCaseProvider));
+  return GetCalculatedPowerMeterDataUseCase(
+      ref.read(getPowerMeterDataUseCaseProvider));
 }
 
 @riverpod
@@ -281,5 +279,3 @@ SaveWorkoutResultUseCase saveWorkoutResultUseCase(Ref ref) {
 GetWorkoutResultsUseCase getWorkoutResultsUseCase(Ref ref) {
   return GetWorkoutResultsUseCase(ref.read(workoutRepositoryProvider));
 }
-
-

--- a/frontend/lib/di/providers.g.dart
+++ b/frontend/lib/di/providers.g.dart
@@ -90,46 +90,6 @@ final authRepositoryProvider = AutoDisposeProvider<AuthRepository>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef AuthRepositoryRef = AutoDisposeProviderRef<AuthRepository>;
-String _$mockModeStateNotifierHash() =>
-    r'b4014b1335839b7cd8940d18d2911adbc19de57b';
-
-/// See also [mockModeStateNotifier].
-@ProviderFor(mockModeStateNotifier)
-final mockModeStateNotifierProvider =
-    AutoDisposeProvider<MockModeStateNotifier>.internal(
-  mockModeStateNotifier,
-  name: r'mockModeStateNotifierProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$mockModeStateNotifierHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-@Deprecated('Will be removed in 3.0. Use Ref instead')
-// ignore: unused_element
-typedef MockModeStateNotifierRef
-    = AutoDisposeProviderRef<MockModeStateNotifier>;
-String _$mockPatternStateNotifierHash() =>
-    r'ff4f1aa8b4c0bb06a18ca637a345a38e1fcbb535';
-
-/// See also [mockPatternStateNotifier].
-@ProviderFor(mockPatternStateNotifier)
-final mockPatternStateNotifierProvider =
-    AutoDisposeProvider<MockPatternStateNotifier>.internal(
-  mockPatternStateNotifier,
-  name: r'mockPatternStateNotifierProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$mockPatternStateNotifierHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-@Deprecated('Will be removed in 3.0. Use Ref instead')
-// ignore: unused_element
-typedef MockPatternStateNotifierRef
-    = AutoDisposeProviderRef<MockPatternStateNotifier>;
 String _$getWorkoutSummariesUseCaseHash() =>
     r'8d8b235dfcadc3ceaf1ca3977c7d77944ac44bad';
 
@@ -298,7 +258,7 @@ final workoutRepositoryProvider =
 // ignore: unused_element
 typedef WorkoutRepositoryRef = AutoDisposeProviderRef<WorkoutRepository>;
 String _$powerMeterDataSourceHash() =>
-    r'dab7543e53197bf24ca9473bd9aa86dc97b3b5b2';
+    r'8882d07ab98e3b2cff2d918f0399c3493fe6b93c';
 
 /// See also [powerMeterDataSource].
 @ProviderFor(powerMeterDataSource)
@@ -605,5 +565,40 @@ final getWorkoutResultsUseCaseProvider =
 // ignore: unused_element
 typedef GetWorkoutResultsUseCaseRef
     = AutoDisposeProviderRef<GetWorkoutResultsUseCase>;
+String _$mockModeHash() => r'4318c20e2959d772a2fa645299853f362d97412f';
+
+/// モックモードの ON/OFF。SharedPreferences に永続化する。
+///
+/// Copied from [MockMode].
+@ProviderFor(MockMode)
+final mockModeProvider = AutoDisposeNotifierProvider<MockMode, bool>.internal(
+  MockMode.new,
+  name: r'mockModeProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$mockModeHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$MockMode = AutoDisposeNotifier<bool>;
+String _$mockPatternSelectionHash() =>
+    r'8acdfc8ef3488da3130279d84c602543e2192277';
+
+/// モックパワーデータのパターン選択。SharedPreferences に永続化する。
+///
+/// Copied from [MockPatternSelection].
+@ProviderFor(MockPatternSelection)
+final mockPatternSelectionProvider =
+    AutoDisposeNotifierProvider<MockPatternSelection, MockPattern>.internal(
+  MockPatternSelection.new,
+  name: r'mockPatternSelectionProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$mockPatternSelectionHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$MockPatternSelection = AutoDisposeNotifier<MockPattern>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/domain/model/mock_pattern.dart
+++ b/frontend/lib/domain/model/mock_pattern.dart
@@ -1,0 +1,14 @@
+/// 開発者メニューで選択するモックパワーデータのパターン。
+///
+/// パターンの「識別子」と「表示名」だけを持つドメインの値。
+/// 実際のモックデータ生成ロジックは data 層（power_meter_data_source.dart の
+/// MockPatternGenerator extension）が担う。
+enum MockPattern {
+  warmup(name: 'ウォームアップ'),
+  interval(name: 'インターバル'),
+  steady(name: 'ステディ'),
+  cooldown(name: 'クールダウン');
+
+  final String name;
+  const MockPattern({required this.name});
+}

--- a/frontend/lib/ui/workout/developer_menu.dart
+++ b/frontend/lib/ui/workout/developer_menu.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:workoutride/data/power_meter_data_source.dart';
+import 'package:workoutride/domain/model/mock_pattern.dart';
 import 'package:workoutride/di/providers.dart';
 
 class DeveloperMenu extends ConsumerWidget {
@@ -8,10 +8,8 @@ class DeveloperMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final mockModeNotifier = ref.watch(mockModeStateNotifierProvider);
-    final mockPatternNotifier = ref.watch(mockPatternStateNotifierProvider);
-    final isMock = mockModeNotifier.value;
-    final currentPattern = mockPatternNotifier.value;
+    final isMock = ref.watch(mockModeProvider);
+    final currentPattern = ref.watch(mockPatternSelectionProvider);
 
     return Container(
       color: Colors.black,
@@ -38,7 +36,7 @@ class DeveloperMenu extends ConsumerWidget {
                   style: TextStyle(color: Colors.white),
                 ),
                 value: isMock,
-                onChanged: (_) => ref.read(mockModeStateNotifierProvider).toggle(),
+                onChanged: (_) => ref.read(mockModeProvider.notifier).toggle(),
               ),
               // パターン選択（モックモード時のみ表示）
               if (isMock) ...[
@@ -65,7 +63,9 @@ class DeveloperMenu extends ConsumerWidget {
                   }).toList(),
                   onChanged: (pattern) {
                     if (pattern != null) {
-                      ref.read(mockPatternStateNotifierProvider).setPattern(pattern);
+                      ref
+                          .read(mockPatternSelectionProvider.notifier)
+                          .setPattern(pattern);
                     }
                   },
                 ),
@@ -76,4 +76,4 @@ class DeveloperMenu extends ConsumerWidget {
       ),
     );
   }
-} 
+}


### PR DESCRIPTION
## 目的
`docs/architecture.md` 移行計画の先行フェーズ（逸脱 C1・B2）。挙動を変えない足場固め。

## 変更
- **C1**: `MockMode` / `MockPatternSelection` を `@riverpod` codegen Notifier 化。
  旧「`@riverpod`関数が`StateNotifier`インスタンスを返す」非リアクティブ実装を解消。
  `ref.watch` が値を直接返すようになり、モードのトグルで `powerMeterDataSource` が正しく再構築される。
- **B2**: `MockPattern` enum を data層 → `domain/model/mock_pattern.dart` に移設（識別子＋表示名のみ）。
  データ生成ロジックは data層の `MockPatternGenerator` extension に分離（data→domain 参照は合法）。
  `developer_menu` の data層 import を解消（UIは domain のみ参照）。

## 確認
- `flutter test` 全緑（27ケース）
- `flutter analyze lib`：本PR変更ファイルに新規指摘なし（既存 info のみ）
- SharedPreferences キー（`mock_mode`/`mock_pattern`）と永続値の互換を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)