### PR TITLE
refactor: workout_detailのFTP取得をViewModelへ (View薄化 B3)

### DIFF
--- a/frontend/lib/ui/workout_detail/workout_detail_screen.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen.dart
@@ -2,19 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/ui/workout_detail/workout_detail_screen_state_notifier.dart';
-import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/ui/workout/workout_screen.dart';
 import 'package:workoutride/ui/theme/app_colors.dart';
 
 class WorkoutDetailScreen extends ConsumerWidget {
   final int workoutId;
-  
+
   const WorkoutDetailScreen({super.key, required this.workoutId});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final uiState = ref.watch(workoutDetailScreenStateNotifierProvider(workoutId));
-    
+    final uiState =
+        ref.watch(workoutDetailScreenStateNotifierProvider(workoutId));
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -38,164 +38,165 @@ class WorkoutDetailScreen extends ConsumerWidget {
 class WorkoutDetailBody extends StatelessWidget {
   final WorkoutDetailScreenUiState uiState;
   final int workoutId;
-  
-  const WorkoutDetailBody({super.key, required this.uiState, required this.workoutId});
+
+  const WorkoutDetailBody(
+      {super.key, required this.uiState, required this.workoutId});
 
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          uiState.workoutSummary?.name ?? 'No name available',
-          style: const TextStyle(color: Colors.white, fontSize: 20),
-          maxLines: 3,
-          overflow: TextOverflow.ellipsis,
-        ),
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 16),
-          child: Text(
-            "ワークアウト内容",
-            style: TextStyle(color: Colors.white, fontSize: 20),
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            uiState.workoutSummary?.name ?? 'No name available',
+            style: const TextStyle(color: Colors.white, fontSize: 20),
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
           ),
-        ),
-        Builder(
-          builder: (context) {
-            if (uiState.isLoading) {
-              return const Center(
-                child: Padding(
-                  padding: EdgeInsets.only(top: 16.0),
-                  child: CircularProgressIndicator(),
-                ),
-              );
-            } else if (uiState.errorMessage != null) {
-              return Center(
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 16.0),
-                  child: Text(
-                    'エラーが発生しました: ${uiState.errorMessage}',
-                    style: const TextStyle(color: Colors.red),
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Text(
+              "ワークアウト内容",
+              style: TextStyle(color: Colors.white, fontSize: 20),
+            ),
+          ),
+          Builder(
+            builder: (context) {
+              if (uiState.isLoading) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 16.0),
+                    child: CircularProgressIndicator(),
                   ),
-                ),
-              );
-            } else if (uiState.workoutBlocks.isEmpty) {
-              return Center(
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 16.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.playlist_remove, size: 64, color: Colors.grey[600]),
-                      const SizedBox(height: 16),
-                      const Text('ワークアウトブロックがありません', style: TextStyle(color: Colors.grey, fontSize: 16)),
-                      const SizedBox(height: 8),
-                      const Text('別のワークアウトを選択してください', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    ],
+                );
+              } else if (uiState.errorMessage != null) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: Text(
+                      'エラーが発生しました: ${uiState.errorMessage}',
+                      style: const TextStyle(color: Colors.red),
+                    ),
                   ),
-                ),
-              );
-            } else {
-              return Column(
-                children: [
-                  WorkoutMenu(blocks: uiState.workoutBlocks, workoutId: workoutId),
-                  const SizedBox(height: 32),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => WorkoutScreen(workoutId: workoutId),
+                );
+              } else if (uiState.workoutBlocks.isEmpty) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.playlist_remove,
+                            size: 64, color: Colors.grey[600]),
+                        const SizedBox(height: 16),
+                        const Text('ワークアウトブロックがありません',
+                            style: TextStyle(color: Colors.grey, fontSize: 16)),
+                        const SizedBox(height: 8),
+                        const Text('別のワークアウトを選択してください',
+                            style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      ],
+                    ),
+                  ),
+                );
+              } else {
+                return Column(
+                  children: [
+                    WorkoutMenu(
+                      blocks: uiState.workoutBlocks,
+                      userFtp: uiState.userFtp,
+                    ),
+                    const SizedBox(height: 32),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  WorkoutScreen(workoutId: workoutId),
+                            ),
+                          );
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.brand,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
                           ),
-                        );
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.brand,
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
                         ),
-                      ),
-                      child: const Text(
-                        'ワークアウト開始',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
+                        child: const Text(
+                          'ワークアウト開始',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ],
-              );
-            }
-          },
-        ),
-      ],
+                  ],
+                );
+              }
+            },
+          ),
+        ],
       ),
     );
   }
 }
 
-class WorkoutMenu extends ConsumerWidget {
+class WorkoutMenu extends StatelessWidget {
   final List<WorkoutBlock> blocks;
-  final int workoutId;
-  
-  const WorkoutMenu({super.key, required this.blocks, required this.workoutId});
+  // 生の FTP。null は未設定を意味し、デフォルト200W＋警告を表示する。
+  final int? userFtp;
+
+  const WorkoutMenu({super.key, required this.blocks, required this.userFtp});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // FTPを取得（デフォルト値200W）
-    
-    return FutureBuilder<int?>(
-      future: ref.read(getUserFtpUseCaseProvider).call(),
-      builder: (context, snapshot) {
-        final ftpOrNull = snapshot.data;
-        final ftpIsDefault = ftpOrNull == null;
-        final ftp = ftpOrNull ?? 200; // デフォルト200W
+  Widget build(BuildContext context) {
+    final ftpIsDefault = userFtp == null;
+    final ftp = userFtp ?? 200; // デフォルト200W
 
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (ftpIsDefault)
-              Container(
-                color: Colors.orange[100],
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: const Row(
-                  children: [
-                    Icon(Icons.warning_amber, color: Colors.orange),
-                    SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        'FTPが未設定のためデフォルト値(200W)を使用しています。設定から変更できます。',
-                        style: TextStyle(fontSize: 12),
-                      ),
-                    ),
-                  ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (ftpIsDefault)
+          Container(
+            color: Colors.orange[100],
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: const Row(
+              children: [
+                Icon(Icons.warning_amber, color: Colors.orange),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'FTPが未設定のためデフォルト値(200W)を使用しています。設定から変更できます。',
+                    style: TextStyle(fontSize: 12),
+                  ),
                 ),
-              ),
-            ListView.separated(
-              itemCount: blocks.length,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemBuilder: (context, index) {
-                final block = blocks[index];
-                final targetWatts = block.calculateTargetPower(ftp);
-                return WorkoutMenuItem(
-                  type: block.blockType,
-                  power: targetWatts,
-                  duration: block.durationSeconds,
-                );
-              },
-              separatorBuilder: (context, index) {
-                return const SizedBox(height: 8);
-              },
+              ],
             ),
-          ],
-        );
-      },
+          ),
+        ListView.separated(
+          itemCount: blocks.length,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemBuilder: (context, index) {
+            final block = blocks[index];
+            final targetWatts = block.calculateTargetPower(ftp);
+            return WorkoutMenuItem(
+              type: block.blockType,
+              power: targetWatts,
+              duration: block.durationSeconds,
+            );
+          },
+          separatorBuilder: (context, index) {
+            return const SizedBox(height: 8);
+          },
+        ),
+      ],
     );
   }
 }
@@ -204,14 +205,14 @@ class WorkoutMenuItem extends StatelessWidget {
   final String type;
   final int power;
   final int duration;
-  
+
   const WorkoutMenuItem({
     super.key,
     required this.type,
     required this.power,
     required this.duration,
   });
-  
+
   String _formatDuration(int seconds) {
     final minutes = seconds ~/ 60;
     final remainingSeconds = seconds % 60;

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.dart
@@ -17,11 +17,14 @@ class WorkoutDetailScreenUiState with _$WorkoutDetailScreenUiState {
     @Default(false) bool isLoading,
     @Default(null) String? errorMessage,
     @Default(null) double? userWeight,
+    // 生の FTP。null は「未設定」を意味し、View 側でデフォルト200W扱い＋警告表示する。
+    @Default(null) int? userFtp,
   }) = _WorkoutDetailScreenUiState;
 }
 
 @riverpod
-class WorkoutDetailScreenStateNotifier extends _$WorkoutDetailScreenStateNotifier {
+class WorkoutDetailScreenStateNotifier
+    extends _$WorkoutDetailScreenStateNotifier {
   late final WorkoutRepository _workoutRepository;
 
   @override
@@ -30,7 +33,20 @@ class WorkoutDetailScreenStateNotifier extends _$WorkoutDetailScreenStateNotifie
     _workoutRepository = ref.read(workoutRepositoryProvider);
     _fetchWorkoutDetail(workoutId);
     _loadUserWeight();
+    _loadUserFtp();
     return state;
+  }
+
+  Future<void> _loadUserFtp() async {
+    try {
+      final ftp = await ref.read(getUserFtpUseCaseProvider).call();
+      // ftp が null（未設定）のときは state.userFtp を null のまま残す。
+      if (ftp != null) {
+        state = state.copyWith(userFtp: ftp);
+      }
+    } catch (_) {
+      // 取得失敗時は未設定扱い（View がデフォルト200W＋警告を表示）。
+    }
   }
 
   Future<void> _fetchWorkoutDetail(int workoutId) async {
@@ -57,7 +73,7 @@ class WorkoutDetailScreenStateNotifier extends _$WorkoutDetailScreenStateNotifie
     try {
       final useCase = ref.read(getUserProfileUseCaseProvider);
       final profile = await useCase();
-      
+
       state = state.copyWith(
         userWeight: profile?.weight ?? 60.0,
       );

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.freezed.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.freezed.dart
@@ -20,7 +20,9 @@ mixin _$WorkoutDetailScreenUiState {
   WorkoutSummary? get workoutSummary => throw _privateConstructorUsedError;
   bool get isLoading => throw _privateConstructorUsedError;
   String? get errorMessage => throw _privateConstructorUsedError;
-  double? get userWeight => throw _privateConstructorUsedError;
+  double? get userWeight =>
+      throw _privateConstructorUsedError; // 生の FTP。null は「未設定」を意味し、View 側でデフォルト200W扱い＋警告表示する。
+  int? get userFtp => throw _privateConstructorUsedError;
 
   /// Create a copy of WorkoutDetailScreenUiState
   /// with the given fields replaced by the non-null parameter values.
@@ -41,7 +43,8 @@ abstract class $WorkoutDetailScreenUiStateCopyWith<$Res> {
       WorkoutSummary? workoutSummary,
       bool isLoading,
       String? errorMessage,
-      double? userWeight});
+      double? userWeight,
+      int? userFtp});
 
   $WorkoutSummaryCopyWith<$Res>? get workoutSummary;
 }
@@ -67,6 +70,7 @@ class _$WorkoutDetailScreenUiStateCopyWithImpl<$Res,
     Object? isLoading = null,
     Object? errorMessage = freezed,
     Object? userWeight = freezed,
+    Object? userFtp = freezed,
   }) {
     return _then(_value.copyWith(
       workoutBlocks: null == workoutBlocks
@@ -89,6 +93,10 @@ class _$WorkoutDetailScreenUiStateCopyWithImpl<$Res,
           ? _value.userWeight
           : userWeight // ignore: cast_nullable_to_non_nullable
               as double?,
+      userFtp: freezed == userFtp
+          ? _value.userFtp
+          : userFtp // ignore: cast_nullable_to_non_nullable
+              as int?,
     ) as $Val);
   }
 
@@ -121,7 +129,8 @@ abstract class _$$WorkoutDetailScreenUiStateImplCopyWith<$Res>
       WorkoutSummary? workoutSummary,
       bool isLoading,
       String? errorMessage,
-      double? userWeight});
+      double? userWeight,
+      int? userFtp});
 
   @override
   $WorkoutSummaryCopyWith<$Res>? get workoutSummary;
@@ -147,6 +156,7 @@ class __$$WorkoutDetailScreenUiStateImplCopyWithImpl<$Res>
     Object? isLoading = null,
     Object? errorMessage = freezed,
     Object? userWeight = freezed,
+    Object? userFtp = freezed,
   }) {
     return _then(_$WorkoutDetailScreenUiStateImpl(
       workoutBlocks: null == workoutBlocks
@@ -169,6 +179,10 @@ class __$$WorkoutDetailScreenUiStateImplCopyWithImpl<$Res>
           ? _value.userWeight
           : userWeight // ignore: cast_nullable_to_non_nullable
               as double?,
+      userFtp: freezed == userFtp
+          ? _value.userFtp
+          : userFtp // ignore: cast_nullable_to_non_nullable
+              as int?,
     ));
   }
 }
@@ -183,7 +197,8 @@ class _$WorkoutDetailScreenUiStateImpl
       this.workoutSummary = null,
       this.isLoading = false,
       this.errorMessage = null,
-      this.userWeight = null})
+      this.userWeight = null,
+      this.userFtp = null})
       : _workoutBlocks = workoutBlocks;
 
   final List<WorkoutBlock> _workoutBlocks;
@@ -207,10 +222,14 @@ class _$WorkoutDetailScreenUiStateImpl
   @override
   @JsonKey()
   final double? userWeight;
+// 生の FTP。null は「未設定」を意味し、View 側でデフォルト200W扱い＋警告表示する。
+  @override
+  @JsonKey()
+  final int? userFtp;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'WorkoutDetailScreenUiState(workoutBlocks: $workoutBlocks, workoutSummary: $workoutSummary, isLoading: $isLoading, errorMessage: $errorMessage, userWeight: $userWeight)';
+    return 'WorkoutDetailScreenUiState(workoutBlocks: $workoutBlocks, workoutSummary: $workoutSummary, isLoading: $isLoading, errorMessage: $errorMessage, userWeight: $userWeight, userFtp: $userFtp)';
   }
 
   @override
@@ -222,7 +241,8 @@ class _$WorkoutDetailScreenUiStateImpl
       ..add(DiagnosticsProperty('workoutSummary', workoutSummary))
       ..add(DiagnosticsProperty('isLoading', isLoading))
       ..add(DiagnosticsProperty('errorMessage', errorMessage))
-      ..add(DiagnosticsProperty('userWeight', userWeight));
+      ..add(DiagnosticsProperty('userWeight', userWeight))
+      ..add(DiagnosticsProperty('userFtp', userFtp));
   }
 
   @override
@@ -239,7 +259,8 @@ class _$WorkoutDetailScreenUiStateImpl
             (identical(other.errorMessage, errorMessage) ||
                 other.errorMessage == errorMessage) &&
             (identical(other.userWeight, userWeight) ||
-                other.userWeight == userWeight));
+                other.userWeight == userWeight) &&
+            (identical(other.userFtp, userFtp) || other.userFtp == userFtp));
   }
 
   @override
@@ -249,7 +270,8 @@ class _$WorkoutDetailScreenUiStateImpl
       workoutSummary,
       isLoading,
       errorMessage,
-      userWeight);
+      userWeight,
+      userFtp);
 
   /// Create a copy of WorkoutDetailScreenUiState
   /// with the given fields replaced by the non-null parameter values.
@@ -268,7 +290,8 @@ abstract class _WorkoutDetailScreenUiState
       final WorkoutSummary? workoutSummary,
       final bool isLoading,
       final String? errorMessage,
-      final double? userWeight}) = _$WorkoutDetailScreenUiStateImpl;
+      final double? userWeight,
+      final int? userFtp}) = _$WorkoutDetailScreenUiStateImpl;
 
   @override
   List<WorkoutBlock> get workoutBlocks;
@@ -279,7 +302,9 @@ abstract class _WorkoutDetailScreenUiState
   @override
   String? get errorMessage;
   @override
-  double? get userWeight;
+  double? get userWeight; // 生の FTP。null は「未設定」を意味し、View 側でデフォルト200W扱い＋警告表示する。
+  @override
+  int? get userFtp;
 
   /// Create a copy of WorkoutDetailScreenUiState
   /// with the given fields replaced by the non-null parameter values.

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'workout_detail_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$workoutDetailScreenStateNotifierHash() =>
-    r'0c38c7abd8b86d52466a20fa389b1bb5436b0f09';
+    r'd8b88276b7d737c33f929906b865fa90a77c13a2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/frontend/test/ui/workout_detail/workout_detail_screen_state_notifier_test.dart
+++ b/frontend/test/ui/workout_detail/workout_detail_screen_state_notifier_test.dart
@@ -7,6 +7,7 @@ import 'package:workoutride/domain/model/user_profile.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/domain/model/workout/workout_summary.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
+import 'package:workoutride/domain/usecase/user_profile/get_user_ftp_use_case.dart';
 import 'package:workoutride/domain/usecase/user_profile/get_user_profile_use_case.dart';
 import 'package:workoutride/ui/workout_detail/workout_detail_screen_state_notifier.dart';
 
@@ -19,11 +20,13 @@ import 'workout_detail_screen_state_notifier_test.mocks.dart';
 @GenerateMocks([
   WorkoutRepository,
   GetUserProfileUseCase,
+  GetUserFtpUseCase,
 ])
 void main() {
   late ProviderContainer container;
   late MockWorkoutRepository mockWorkoutRepository;
   late MockGetUserProfileUseCase mockGetUserProfileUseCase;
+  late MockGetUserFtpUseCase mockGetUserFtpUseCase;
 
   const testWorkoutId = 1;
 
@@ -64,6 +67,7 @@ void main() {
           workoutRepositoryProvider.overrideWithValue(mockWorkoutRepository),
           getUserProfileUseCaseProvider
               .overrideWithValue(mockGetUserProfileUseCase),
+          getUserFtpUseCaseProvider.overrideWithValue(mockGetUserFtpUseCase),
         ],
       );
 
@@ -76,6 +80,9 @@ void main() {
   setUp(() {
     mockWorkoutRepository = MockWorkoutRepository();
     mockGetUserProfileUseCase = MockGetUserProfileUseCase();
+    mockGetUserFtpUseCase = MockGetUserFtpUseCase();
+    // 既定では FTP=250 を返す（未設定ケースのテストで個別に上書き）。
+    when(mockGetUserFtpUseCase.call()).thenAnswer((_) async => 250);
     container = buildContainer();
   });
 
@@ -89,8 +96,8 @@ void main() {
           .thenAnswer((_) async => testSummary);
       when(mockWorkoutRepository.getWorkoutBlocks(testWorkoutId))
           .thenAnswer((_) async => testBlocks);
-      when(mockGetUserProfileUseCase.call()).thenAnswer(
-          (_) async => UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
+      when(mockGetUserProfileUseCase.call()).thenAnswer((_) async =>
+          UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
 
       final state = container
           .read(workoutDetailScreenStateNotifierProvider(testWorkoutId));
@@ -105,12 +112,12 @@ void main() {
           .thenAnswer((_) async => testSummary);
       when(mockWorkoutRepository.getWorkoutBlocks(testWorkoutId))
           .thenAnswer((_) async => testBlocks);
-      when(mockGetUserProfileUseCase.call()).thenAnswer(
-          (_) async => UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
+      when(mockGetUserProfileUseCase.call()).thenAnswer((_) async =>
+          UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
 
       keepAlive();
-      container
-          .read(workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
+      container.read(
+          workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
       await Future.delayed(const Duration(milliseconds: 50));
 
       final state = container
@@ -120,6 +127,26 @@ void main() {
       expect(state.workoutSummary, testSummary);
       expect(state.workoutBlocks, testBlocks);
       expect(state.userWeight, 70);
+      expect(state.userFtp, 250);
+    });
+
+    test('FTP が未設定(null)のときは userFtp を null のままにする', () async {
+      when(mockWorkoutRepository.getWorkoutSummary(testWorkoutId))
+          .thenAnswer((_) async => testSummary);
+      when(mockWorkoutRepository.getWorkoutBlocks(testWorkoutId))
+          .thenAnswer((_) async => testBlocks);
+      when(mockGetUserProfileUseCase.call()).thenAnswer((_) async =>
+          UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
+      when(mockGetUserFtpUseCase.call()).thenAnswer((_) async => null);
+
+      keepAlive();
+      container.read(
+          workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final state = container
+          .read(workoutDetailScreenStateNotifierProvider(testWorkoutId));
+      expect(state.userFtp, isNull);
     });
 
     test('プロフィールが null のときは体重 60.0 にフォールバックする', () async {
@@ -130,8 +157,8 @@ void main() {
       when(mockGetUserProfileUseCase.call()).thenAnswer((_) async => null);
 
       keepAlive();
-      container
-          .read(workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
+      container.read(
+          workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
       await Future.delayed(const Duration(milliseconds: 50));
 
       final state = container
@@ -148,8 +175,8 @@ void main() {
           .thenThrow(Exception('profile error'));
 
       keepAlive();
-      container
-          .read(workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
+      container.read(
+          workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
       await Future.delayed(const Duration(milliseconds: 50));
 
       final state = container
@@ -162,12 +189,12 @@ void main() {
           .thenThrow(Exception('load error'));
       when(mockWorkoutRepository.getWorkoutBlocks(testWorkoutId))
           .thenAnswer((_) async => testBlocks);
-      when(mockGetUserProfileUseCase.call()).thenAnswer(
-          (_) async => UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
+      when(mockGetUserProfileUseCase.call()).thenAnswer((_) async =>
+          UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
 
       keepAlive();
-      container
-          .read(workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
+      container.read(
+          workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
       await Future.delayed(const Duration(milliseconds: 50));
 
       final state = container
@@ -181,12 +208,12 @@ void main() {
           .thenAnswer((_) async => testSummary);
       when(mockWorkoutRepository.getWorkoutBlocks(testWorkoutId))
           .thenAnswer((_) async => testBlocks);
-      when(mockGetUserProfileUseCase.call()).thenAnswer(
-          (_) async => UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
+      when(mockGetUserProfileUseCase.call()).thenAnswer((_) async =>
+          UserProfile(weight: 70, ftp: 250, updatedAt: DateTime(2023)));
 
       keepAlive();
-      final notifier = container
-          .read(workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
+      final notifier = container.read(
+          workoutDetailScreenStateNotifierProvider(testWorkoutId).notifier);
       await Future.delayed(const Duration(milliseconds: 50));
 
       await notifier.refreshWorkoutBlocks(testWorkoutId);

--- a/frontend/test/ui/workout_detail/workout_detail_screen_state_notifier_test.mocks.dart
+++ b/frontend/test/ui/workout_detail/workout_detail_screen_state_notifier_test.mocks.dart
@@ -15,6 +15,8 @@ import 'package:workoutride/domain/model/workout/workout_summary.dart' as _i2;
 import 'package:workoutride/domain/repository/user_profile_repository.dart'
     as _i4;
 import 'package:workoutride/domain/repository/workout_repository.dart' as _i5;
+import 'package:workoutride/domain/usecase/user_profile/get_user_ftp_use_case.dart'
+    as _i11;
 import 'package:workoutride/domain/usecase/user_profile/get_user_profile_use_case.dart'
     as _i9;
 
@@ -181,4 +183,22 @@ class MockGetUserProfileUseCase extends _i1.Mock
         ),
         returnValue: _i6.Future<_i10.UserProfile?>.value(),
       ) as _i6.Future<_i10.UserProfile?>);
+}
+
+/// A class which mocks [GetUserFtpUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGetUserFtpUseCase extends _i1.Mock implements _i11.GetUserFtpUseCase {
+  MockGetUserFtpUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i6.Future<int?> call() => (super.noSuchMethod(
+        Invocation.method(
+          #call,
+          [],
+        ),
+        returnValue: _i6.Future<int?>.value(),
+      ) as _i6.Future<int?>);
 }


### PR DESCRIPTION
## 目的
`docs/architecture.md` §2.1/§6.2 の B3。View 内のデータ取得（`FutureBuilder` + UseCase 直呼び）を排除し、ViewModel に吸い上げる。

## 変更
- `WorkoutDetailScreenUiState` に nullable `userFtp` を追加（`null` = 未設定）。ViewModel が `getUserFtpUseCase` で取得して state に載せる。
- `WorkoutMenu` を `ConsumerWidget` → `StatelessWidget` 化。`FutureBuilder` を撤去し、`blocks` + `userFtp` を受け取って描画するだけに。不要な `workoutId`/`ref`/`di/providers` import を削除。

### 補足（なぜ FTP を別取得するか）
`getUserProfile().ftp` は実装上 `ftp ?? 200` に丸められ「未設定かどうか」を失う。警告バナー（FTP未設定→デフォルト200W）の判定には生の `getFtp()` 値（`int?`）が必要なため、profile とは別に取得する。

## テスト
- `userFtp` の反映（250）と未設定時に `null` を維持することを追加検証。
- `flutter test` 全緑（40）、`flutter analyze` 指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)