### PR TITLE
refactor: 集計ロジックをWorkoutResultRecorderへ抽出＋単体テスト (D2)

### DIFF
--- a/frontend/lib/domain/service/workout_result_recorder.dart
+++ b/frontend/lib/domain/service/workout_result_recorder.dart
@@ -1,0 +1,130 @@
+import 'package:workoutride/domain/model/workout/workout_block.dart';
+import 'package:workoutride/domain/model/workout/workout_result_draft.dart';
+
+/// ワークアウト中のパワー/ケイデンス計測値を蓄積し、
+/// 保存用の [WorkoutResultDraft] を組み立てる純粋なドメインサービス。
+///
+/// Riverpod や Flutter に依存しないため単体テストが容易。ViewModel
+/// （WorkoutScreenStateNotifier）から集計ロジックを切り出したもの。
+class WorkoutResultRecorder {
+  final List<WorkoutBlock> _blocks;
+  final DateTime _startedAt;
+
+  int _overallMaxPower = 0;
+  final List<int> _allPowerReadings = [];
+  final List<int> _allCadenceReadings = [];
+  // ブロックごとの記録
+  final List<List<int>> _blockPowerReadings;
+  final List<List<int>> _blockCadenceReadings;
+  final List<int> _blockMaxPowers;
+
+  WorkoutResultRecorder({
+    required List<WorkoutBlock> blocks,
+    required DateTime startedAt,
+  })  : _blocks = blocks,
+        _startedAt = startedAt,
+        _blockPowerReadings = List.generate(blocks.length, (_) => <int>[]),
+        _blockCadenceReadings = List.generate(blocks.length, (_) => <int>[]),
+        _blockMaxPowers = List.filled(blocks.length, 0, growable: true);
+
+  /// 1件の計測値を、その時点の [blockIndex]（現在ブロック）に紐づけて記録する。
+  /// power / cadence が 0 のものは無効値として集計対象から除外する。
+  void record({
+    required int power,
+    required int cadence,
+    required int blockIndex,
+  }) {
+    // 全体の記録
+    if (power > 0) {
+      _allPowerReadings.add(power);
+      if (power > _overallMaxPower) {
+        _overallMaxPower = power;
+      }
+    }
+    if (cadence > 0) {
+      _allCadenceReadings.add(cadence);
+    }
+
+    // 現在ブロックの記録
+    if (blockIndex >= 0 && blockIndex < _blockPowerReadings.length) {
+      if (power > 0) {
+        _blockPowerReadings[blockIndex].add(power);
+        if (power > _blockMaxPowers[blockIndex]) {
+          _blockMaxPowers[blockIndex] = power;
+        }
+      }
+      if (cadence > 0) {
+        _blockCadenceReadings[blockIndex].add(cadence);
+      }
+    }
+  }
+
+  /// 蓄積した計測値から保存用 Draft を組み立てる。
+  ///
+  /// [status] が 'abandoned' の場合、[currentBlockIndex] より後ろのブロックは
+  /// 結果に含めない。[currentBlockIndex] のブロック時間は、経過時間から
+  /// それ以前のブロックの合計時間を引いて算出する。
+  WorkoutResultDraft buildDraft({
+    required String status,
+    required int currentBlockIndex,
+    required int elapsedSeconds,
+    required DateTime finishedAt,
+  }) {
+    final averagePower = _average(_allPowerReadings);
+    final averageCadence = _average(_allCadenceReadings);
+
+    final blockResults = <WorkoutBlockResultDraft>[];
+    for (var i = 0; i < _blocks.length; i++) {
+      if (i > currentBlockIndex && status == 'abandoned') break;
+
+      final blockPowers =
+          _blockPowerReadings.length > i ? _blockPowerReadings[i] : <int>[];
+      final blockCadences =
+          _blockCadenceReadings.length > i ? _blockCadenceReadings[i] : <int>[];
+      final blockMaxPower =
+          _blockMaxPowers.length > i ? _blockMaxPowers[i] : null;
+
+      // 実際に経過したブロック時間を計算
+      int blockDuration;
+      if (i < currentBlockIndex) {
+        blockDuration = _blocks[i].durationSeconds;
+      } else if (i == currentBlockIndex) {
+        var previousBlocksTime = 0;
+        for (var j = 0; j < i; j++) {
+          previousBlocksTime += _blocks[j].durationSeconds;
+        }
+        blockDuration = elapsedSeconds - previousBlocksTime;
+        if (blockDuration < 0) blockDuration = 0;
+      } else {
+        blockDuration = 0;
+      }
+
+      blockResults.add(WorkoutBlockResultDraft(
+        workoutBlockId: _blocks[i].id,
+        averagePower: _average(blockPowers),
+        maxPower:
+            blockMaxPower != null && blockMaxPower > 0 ? blockMaxPower : null,
+        averageCadence: _average(blockCadences),
+        durationSeconds: blockDuration,
+      ));
+    }
+
+    return WorkoutResultDraft(
+      workoutSummaryId: _blocks.first.workoutId,
+      startedAt: _startedAt,
+      finishedAt: finishedAt,
+      totalDurationSeconds: elapsedSeconds,
+      averagePower: averagePower,
+      maxPower: _overallMaxPower > 0 ? _overallMaxPower : null,
+      averageCadence: averageCadence,
+      status: status,
+      blockResults: blockResults,
+    );
+  }
+
+  /// 空なら null、そうでなければ四捨五入した平均値。
+  static int? _average(List<int> values) {
+    if (values.isEmpty) return null;
+    return (values.reduce((a, b) => a + b) / values.length).round();
+  }
+}

--- a/frontend/lib/ui/workout/workout_screen_state_notifier.dart
+++ b/frontend/lib/ui/workout/workout_screen_state_notifier.dart
@@ -4,10 +4,10 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
-import 'package:workoutride/domain/model/workout/workout_result_draft.dart';
 import 'package:workoutride/domain/model/power_alert_message.dart';
 import 'package:workoutride/domain/repository/user_profile_repository.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
+import 'package:workoutride/domain/service/workout_result_recorder.dart';
 import 'package:workoutride/domain/usecase/get_calculated_power_meter_data_usecase.dart';
 import 'package:workoutride/domain/usecase/workout/manage_workout_use_case.dart';
 
@@ -54,15 +54,8 @@ class WorkoutScreenStateNotifier extends _$WorkoutScreenStateNotifier {
   Timer? _countdownTimer;
   Timer? _completionTimer;
 
-  // ワークアウト結果の記録用
-  DateTime? _workoutStartedAt;
-  int _overallMaxPower = 0;
-  final List<int> _allPowerReadings = [];
-  final List<int> _allCadenceReadings = [];
-  // ブロックごとの記録
-  final List<List<int>> _blockPowerReadings = [];
-  final List<List<int>> _blockCadenceReadings = [];
-  final List<int> _blockMaxPowers = [];
+  // ワークアウト結果の集計は WorkoutResultRecorder（純粋ドメインサービス）へ委譲。
+  WorkoutResultRecorder? _recorder;
   int _lastBlockIndex = 0;
 
   @override
@@ -111,20 +104,11 @@ class WorkoutScreenStateNotifier extends _$WorkoutScreenStateNotifier {
   void _startWorkoutAfterCountdown() {
     if (state.workoutBlocks.isEmpty) return;
 
-    _workoutStartedAt = DateTime.now();
     _lastBlockIndex = 0;
-    _overallMaxPower = 0;
-    _allPowerReadings.clear();
-    _allCadenceReadings.clear();
-    _blockPowerReadings.clear();
-    _blockCadenceReadings.clear();
-    _blockMaxPowers.clear();
-    // ブロックごとの記録用リストを初期化
-    for (var i = 0; i < state.workoutBlocks.length; i++) {
-      _blockPowerReadings.add([]);
-      _blockCadenceReadings.add([]);
-      _blockMaxPowers.add(0);
-    }
+    _recorder = WorkoutResultRecorder(
+      blocks: state.workoutBlocks,
+      startedAt: DateTime.now(),
+    );
 
     // ManageWorkoutUseCaseのストリームを購読し、UiStateへ反映
     _workoutSubscription =
@@ -164,30 +148,11 @@ class WorkoutScreenStateNotifier extends _$WorkoutScreenStateNotifier {
       final power = powerMeterData.power;
       final cadence = powerMeterData.cadence;
 
-      // 全体の記録
-      if (power > 0) {
-        _allPowerReadings.add(power);
-        if (power > _overallMaxPower) {
-          _overallMaxPower = power;
-        }
-      }
-      if (cadence > 0) {
-        _allCadenceReadings.add(cadence);
-      }
-
-      // 現在ブロックの記録
-      final blockIndex = state.currentBlockIndex;
-      if (blockIndex < _blockPowerReadings.length) {
-        if (power > 0) {
-          _blockPowerReadings[blockIndex].add(power);
-          if (power > _blockMaxPowers[blockIndex]) {
-            _blockMaxPowers[blockIndex] = power;
-          }
-        }
-        if (cadence > 0) {
-          _blockCadenceReadings[blockIndex].add(cadence);
-        }
-      }
+      _recorder?.record(
+        power: power,
+        cadence: cadence,
+        blockIndex: state.currentBlockIndex,
+      );
 
       state = state.copyWith(
         power: power,
@@ -261,77 +226,17 @@ class WorkoutScreenStateNotifier extends _$WorkoutScreenStateNotifier {
   }
 
   Future<void> _saveResult(String status) async {
-    if (_workoutStartedAt == null || state.workoutBlocks.isEmpty) return;
+    if (_recorder == null || state.workoutBlocks.isEmpty) return;
     if (state.isSavingResult || state.isResultSaved) return;
 
     state = state.copyWith(isSavingResult: true);
 
     try {
-      final now = DateTime.now();
-      final averagePower = _allPowerReadings.isNotEmpty
-          ? (_allPowerReadings.reduce((a, b) => a + b) /
-                  _allPowerReadings.length)
-              .round()
-          : null;
-      final averageCadence = _allCadenceReadings.isNotEmpty
-          ? (_allCadenceReadings.reduce((a, b) => a + b) /
-                  _allCadenceReadings.length)
-              .round()
-          : null;
-
-      final blockResults = <WorkoutBlockResultDraft>[];
-      for (var i = 0; i < state.workoutBlocks.length; i++) {
-        if (i > state.currentBlockIndex && status == 'abandoned') break;
-
-        final blockPowers =
-            _blockPowerReadings.length > i ? _blockPowerReadings[i] : <int>[];
-        final blockCadences = _blockCadenceReadings.length > i
-            ? _blockCadenceReadings[i]
-            : <int>[];
-        final blockMaxPower =
-            _blockMaxPowers.length > i ? _blockMaxPowers[i] : null;
-
-        // 実際に経過したブロック時間を計算
-        int blockDuration;
-        if (i < state.currentBlockIndex) {
-          blockDuration = state.workoutBlocks[i].durationSeconds;
-        } else if (i == state.currentBlockIndex) {
-          int previousBlocksTime = 0;
-          for (var j = 0; j < i; j++) {
-            previousBlocksTime += state.workoutBlocks[j].durationSeconds;
-          }
-          blockDuration = state.elapsedSeconds - previousBlocksTime;
-          if (blockDuration < 0) blockDuration = 0;
-        } else {
-          blockDuration = 0;
-        }
-
-        blockResults.add(WorkoutBlockResultDraft(
-          workoutBlockId: state.workoutBlocks[i].id,
-          averagePower: blockPowers.isNotEmpty
-              ? (blockPowers.reduce((a, b) => a + b) / blockPowers.length)
-                  .round()
-              : null,
-          maxPower:
-              blockMaxPower != null && blockMaxPower > 0 ? blockMaxPower : null,
-          averageCadence: blockCadences.isNotEmpty
-              ? (blockCadences.reduce((a, b) => a + b) / blockCadences.length)
-                  .round()
-              : null,
-          durationSeconds: blockDuration,
-        ));
-      }
-
-      final draft = WorkoutResultDraft(
-        workoutSummaryId: state.workoutBlocks.first.workoutId,
-        startedAt: _workoutStartedAt!,
-        finishedAt: now,
-        totalDurationSeconds: state.elapsedSeconds,
-        averagePower: averagePower,
-        maxPower: _overallMaxPower > 0 ? _overallMaxPower : null,
-        averageCadence: averageCadence,
+      final draft = _recorder!.buildDraft(
         status: status,
-        blockResults: blockResults,
+        currentBlockIndex: state.currentBlockIndex,
+        elapsedSeconds: state.elapsedSeconds,
+        finishedAt: DateTime.now(),
       );
 
       await _workoutRepository.saveWorkoutResult(draft);

--- a/frontend/lib/ui/workout/workout_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/workout/workout_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'workout_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$workoutScreenStateNotifierHash() =>
-    r'0697dfec5247d5415c697a057ff23ee86e2bdccb';
+    r'7627b5197db16e7fbf6ddfbbbcd6ce706da3630b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/frontend/test/domain/service/workout_result_recorder_test.dart
+++ b/frontend/test/domain/service/workout_result_recorder_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workoutride/domain/model/workout/workout_block.dart';
+import 'package:workoutride/domain/service/workout_result_recorder.dart';
+
+// ファット ViewModel から抽出した集計ロジックの単体テスト。
+// PR④/⑥ まで保護テストが無かった _saveResult 相当の集計を、純粋クラスとして固定する。
+void main() {
+  WorkoutBlock block(int id, int order, int durationSeconds) => WorkoutBlock(
+        id: id,
+        workoutId: 100,
+        blockType: 'block$order',
+        targetFtpPercentage: 60,
+        durationSeconds: durationSeconds,
+        orderIndex: order,
+        createdAt: DateTime(2023),
+        updatedAt: DateTime(2023),
+      );
+
+  final startedAt = DateTime.utc(2023, 1, 1, 0, 0, 0);
+  final finishedAt = DateTime.utc(2023, 1, 1, 0, 15, 0);
+
+  group('WorkoutResultRecorder', () {
+    test('completed: 全体・ブロックの平均/最大を集計し Draft を作る', () {
+      final blocks = [block(1, 1, 300), block(2, 2, 600)];
+      final recorder =
+          WorkoutResultRecorder(blocks: blocks, startedAt: startedAt);
+
+      // block 0 に 3件、block 1 に 2件記録
+      recorder.record(power: 100, cadence: 80, blockIndex: 0);
+      recorder.record(power: 200, cadence: 90, blockIndex: 0);
+      recorder.record(power: 150, cadence: 100, blockIndex: 0);
+      recorder.record(power: 300, cadence: 70, blockIndex: 1);
+      recorder.record(power: 100, cadence: 90, blockIndex: 1);
+
+      final draft = recorder.buildDraft(
+        status: 'completed',
+        currentBlockIndex: 1,
+        elapsedSeconds: 900,
+        finishedAt: finishedAt,
+      );
+
+      expect(draft.workoutSummaryId, 100);
+      expect(draft.startedAt, startedAt);
+      expect(draft.finishedAt, finishedAt);
+      expect(draft.totalDurationSeconds, 900);
+      expect(draft.status, 'completed');
+      // 全体平均: (100+200+150+300+100)/5 = 170, 最大 300
+      expect(draft.averagePower, 170);
+      expect(draft.maxPower, 300);
+      // 全体ケイデンス平均: (80+90+100+70+90)/5 = 86
+      expect(draft.averageCadence, 86);
+
+      expect(draft.blockResults.length, 2);
+      final b0 = draft.blockResults[0];
+      expect(b0.workoutBlockId, 1);
+      expect(b0.averagePower, 150); // (100+200+150)/3
+      expect(b0.maxPower, 200);
+      expect(b0.averageCadence, 90); // (80+90+100)/3
+      expect(b0.durationSeconds, 300); // 完了ブロックは満了時間
+      final b1 = draft.blockResults[1];
+      expect(b1.workoutBlockId, 2);
+      expect(b1.averagePower, 200); // (300+100)/2
+      expect(b1.maxPower, 300);
+      // 現在ブロック時間 = elapsed(900) - 前ブロック合計(300) = 600
+      expect(b1.durationSeconds, 600);
+    });
+
+    test('power/cadence が 0 の計測値は集計から除外される', () {
+      final blocks = [block(1, 1, 300)];
+      final recorder =
+          WorkoutResultRecorder(blocks: blocks, startedAt: startedAt);
+
+      recorder.record(power: 0, cadence: 0, blockIndex: 0);
+      recorder.record(power: 200, cadence: 0, blockIndex: 0);
+      recorder.record(power: 0, cadence: 90, blockIndex: 0);
+
+      final draft = recorder.buildDraft(
+        status: 'completed',
+        currentBlockIndex: 0,
+        elapsedSeconds: 300,
+        finishedAt: finishedAt,
+      );
+
+      expect(draft.averagePower, 200); // 0 は除外され 200 のみ
+      expect(draft.averageCadence, 90); // 0 は除外され 90 のみ
+      expect(draft.maxPower, 200);
+    });
+
+    test('計測値ゼロ件のブロックは平均/最大が null', () {
+      final blocks = [block(1, 1, 300)];
+      final recorder =
+          WorkoutResultRecorder(blocks: blocks, startedAt: startedAt);
+
+      final draft = recorder.buildDraft(
+        status: 'completed',
+        currentBlockIndex: 0,
+        elapsedSeconds: 300,
+        finishedAt: finishedAt,
+      );
+
+      expect(draft.averagePower, isNull);
+      expect(draft.averageCadence, isNull);
+      expect(draft.maxPower, isNull);
+      expect(draft.blockResults.single.averagePower, isNull);
+      expect(draft.blockResults.single.maxPower, isNull);
+      expect(draft.blockResults.single.averageCadence, isNull);
+    });
+
+    test('abandoned: 現在ブロックより後ろのブロックは結果に含めない', () {
+      final blocks = [block(1, 1, 300), block(2, 2, 600), block(3, 3, 300)];
+      final recorder =
+          WorkoutResultRecorder(blocks: blocks, startedAt: startedAt);
+      recorder.record(power: 150, cadence: 80, blockIndex: 0);
+      recorder.record(power: 200, cadence: 85, blockIndex: 1);
+
+      final draft = recorder.buildDraft(
+        status: 'abandoned',
+        currentBlockIndex: 1,
+        elapsedSeconds: 500,
+        finishedAt: finishedAt,
+      );
+
+      // block 2（index2）は含まれない
+      expect(draft.blockResults.length, 2);
+      expect(draft.blockResults[0].workoutBlockId, 1);
+      expect(draft.blockResults[1].workoutBlockId, 2);
+      // 現在ブロック(index1)の時間 = 500 - 300 = 200
+      expect(draft.blockResults[1].durationSeconds, 200);
+      expect(draft.status, 'abandoned');
+    });
+
+    test('現在ブロック時間が負になる場合は 0 にクランプする', () {
+      final blocks = [block(1, 1, 300), block(2, 2, 600)];
+      final recorder =
+          WorkoutResultRecorder(blocks: blocks, startedAt: startedAt);
+
+      // elapsed(200) < 前ブロック合計(300) → 負になるが 0 に
+      final draft = recorder.buildDraft(
+        status: 'abandoned',
+        currentBlockIndex: 1,
+        elapsedSeconds: 200,
+        finishedAt: finishedAt,
+      );
+
+      expect(draft.blockResults[1].durationSeconds, 0);
+    });
+  });
+}


### PR DESCRIPTION
## 目的
`docs/architecture.md` §2.2/§2.6（逸脱 D2）。ファット ViewModel（約350行）から結果集計ロジックを純粋ドメインサービスへ抽出し、テスト容易性を確保する。

## 変更
- `domain/service/workout_result_recorder.dart` を追加。計測値の蓄積（`record`）と保存用 Draft 組み立て（`buildDraft`）を担う純粋クラス（Riverpod/Flutter 非依存）。**挙動は旧 `_saveResult` と等価**。
- `workout_screen_state_notifier` から集計用フィールド群（`_allPowerReadings` 等）と `_saveResult` 内の集計ロジックを撤去し、`_recorder` に委譲。

## テスト（保留分の回収）
これまで 15秒カウントダウン＋rxdart ストリーム駆動のため end-to-end 固定が困難だった集計を、純関数として新規に単体テスト：
- completed の全体/ブロック平均・最大・ブロック時間
- power/cadence の 0 値除外、計測ゼロ件ブロックの null
- abandoned で現在ブロックより後を除外
- 現在ブロック時間の負値クランプ

`flutter test` 全緑（45ケース）。

## 補足
これで docs/architecture.md の主要逸脱（A1/A3/B1/B2/C1/D1/D2/B3）はほぼ解消。残りは Phase 6（任意：A2 BLEポート化 / E1 データ層3段 / E2 DI分割 / feature-first / Riverpod3）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)