### PR TITLE
fix: 通信エラーを分類しユーザーへわかりやすいメッセージを表示する

### DIFF
--- a/frontend/lib/data/remote/error/exception_mapper.dart
+++ b/frontend/lib/data/remote/error/exception_mapper.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
 import 'package:workoutride/domain/model/error/app_exception.dart';
 
 /// DioExceptionなどの外部例外を[AppException]へ分類する。
-/// リポジトリ実装のcatchブロックから呼び出す。
+/// リポジトリ実装からは直接呼ばず、[guardApiCall]経由で使う。
 AppException mapToAppException(Object error) {
   if (error is AppException) return error;
 
@@ -27,5 +30,27 @@ AppException mapToAppException(Object error) {
     }
   }
 
+  if (error is SocketException) return const AppException.network();
+
+  // google_sign_in等プラットフォームプラグインは通信断をPlatformExceptionで返すことがある。
+  if (error is PlatformException) {
+    final code = error.code.toLowerCase();
+    final message = (error.message ?? '').toLowerCase();
+    if (code.contains('network') ||
+        message.contains('network') ||
+        message.contains('socket')) {
+      return const AppException.network();
+    }
+  }
+
   return AppException.unknown(error.toString());
+}
+
+/// リポジトリ実装の各メソッドをこれで包み、例外を[AppException]へ変換して送出する。
+Future<T> guardApiCall<T>(Future<T> Function() call) async {
+  try {
+    return await call();
+  } catch (e) {
+    throw mapToAppException(e);
+  }
 }

--- a/frontend/lib/data/remote/error/exception_mapper.dart
+++ b/frontend/lib/data/remote/error/exception_mapper.dart
@@ -1,0 +1,31 @@
+import 'package:dio/dio.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
+
+/// DioExceptionなどの外部例外を[AppException]へ分類する。
+/// リポジトリ実装のcatchブロックから呼び出す。
+AppException mapToAppException(Object error) {
+  if (error is AppException) return error;
+
+  if (error is DioException) {
+    switch (error.type) {
+      case DioExceptionType.connectionError:
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.sendTimeout:
+        return const AppException.network();
+      case DioExceptionType.badResponse:
+        final statusCode = error.response?.statusCode;
+        if (statusCode == 401) return const AppException.unauthorized();
+        if (statusCode != null && statusCode >= 500) {
+          return AppException.server(statusCode);
+        }
+        return AppException.unknown(error.message ?? error.toString());
+      case DioExceptionType.cancel:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.unknown:
+        return const AppException.network();
+    }
+  }
+
+  return AppException.unknown(error.toString());
+}

--- a/frontend/lib/data/repository/auth_repository_impl.dart
+++ b/frontend/lib/data/repository/auth_repository_impl.dart
@@ -18,37 +18,31 @@ class AuthRepositoryImpl implements AuthRepository {
     this._secureStorage,
   );
 
-  Future<T> _guard<T>(Future<T> Function() call) async {
-    try {
-      return await call();
-    } catch (e) {
-      throw mapToAppException(e);
-    }
-  }
-
   @override
   Future<User> signInWithGoogle() async {
-    // 1. Google Sign-In
-    final googleUser = await _googleSignIn.signIn();
-    if (googleUser == null) {
-      throw Exception('Google sign in cancelled');
-    }
+    return guardApiCall(() async {
+      // 1. Google Sign-In
+      final googleUser = await _googleSignIn.signIn();
+      if (googleUser == null) {
+        throw Exception('Google sign in cancelled');
+      }
 
-    final googleAuth = await googleUser.authentication;
-    if (googleAuth.idToken == null) {
-      throw Exception('Failed to get ID token');
-    }
+      final googleAuth = await googleUser.authentication;
+      if (googleAuth.idToken == null) {
+        throw Exception('Failed to get ID token');
+      }
 
-    // 2. Backend認証
-    final response = await _guard(
-      () => _apiClient.googleSignIn({'id_token': googleAuth.idToken!}),
-    );
+      // 2. Backend認証
+      final response = await _apiClient.googleSignIn({
+        'id_token': googleAuth.idToken!,
+      });
 
-    // 3. トークン保存
-    await _secureStorage.write(key: _tokenKey, value: response.token);
+      // 3. トークン保存
+      await _secureStorage.write(key: _tokenKey, value: response.token);
 
-    // 4. Userを返す（provider, uid含む）
-    return response.user.toDomain();
+      // 4. Userを返す（provider, uid含む）
+      return response.user.toDomain();
+    });
   }
 
   @override

--- a/frontend/lib/data/repository/auth_repository_impl.dart
+++ b/frontend/lib/data/repository/auth_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:workoutride/data/remote/api/auth_api_client.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/domain/model/auth/user.dart';
 import 'package:workoutride/domain/repository/auth_repository.dart';
 
@@ -17,6 +18,14 @@ class AuthRepositoryImpl implements AuthRepository {
     this._secureStorage,
   );
 
+  Future<T> _guard<T>(Future<T> Function() call) async {
+    try {
+      return await call();
+    } catch (e) {
+      throw mapToAppException(e);
+    }
+  }
+
   @override
   Future<User> signInWithGoogle() async {
     // 1. Google Sign-In
@@ -31,9 +40,9 @@ class AuthRepositoryImpl implements AuthRepository {
     }
 
     // 2. Backend認証
-    final response = await _apiClient.googleSignIn({
-      'id_token': googleAuth.idToken!,
-    });
+    final response = await _guard(
+      () => _apiClient.googleSignIn({'id_token': googleAuth.idToken!}),
+    );
 
     // 3. トークン保存
     await _secureStorage.write(key: _tokenKey, value: response.token);

--- a/frontend/lib/data/repository/user_profile_repository_impl.dart
+++ b/frontend/lib/data/repository/user_profile_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workoutride/data/remote/api/user_ftp_api_client.dart';
 import 'package:workoutride/data/remote/api/user_profile_api_client.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/domain/model/user_profile.dart';
 import 'package:workoutride/domain/repository/user_profile_repository.dart';
 
@@ -49,13 +50,17 @@ class UserProfileRepositoryImpl implements UserProfileRepository {
       if (e.response?.statusCode == 404) {
         return await _migrateLocalFtpToBackend();
       }
-      rethrow;
+      throw mapToAppException(e);
     }
   }
 
   @override
   Future<void> saveFtp(int ftp) async {
-    await userFtpApiClient.saveFtp({'ftp_value': ftp});
+    try {
+      await userFtpApiClient.saveFtp({'ftp_value': ftp});
+    } catch (e) {
+      throw mapToAppException(e);
+    }
   }
 
   @override
@@ -71,7 +76,11 @@ class UserProfileRepositoryImpl implements UserProfileRepository {
 
   @override
   Future<void> saveWeight(double weight) async {
-    await userProfileApiClient.updateUserProfile({'weight': weight});
+    try {
+      await userProfileApiClient.updateUserProfile({'weight': weight});
+    } catch (e) {
+      throw mapToAppException(e);
+    }
   }
 
   Future<int?> _migrateLocalFtpToBackend() async {

--- a/frontend/lib/data/repository/user_profile_repository_impl.dart
+++ b/frontend/lib/data/repository/user_profile_repository_impl.dart
@@ -55,12 +55,8 @@ class UserProfileRepositoryImpl implements UserProfileRepository {
   }
 
   @override
-  Future<void> saveFtp(int ftp) async {
-    try {
-      await userFtpApiClient.saveFtp({'ftp_value': ftp});
-    } catch (e) {
-      throw mapToAppException(e);
-    }
+  Future<void> saveFtp(int ftp) {
+    return guardApiCall(() => userFtpApiClient.saveFtp({'ftp_value': ftp}));
   }
 
   @override
@@ -75,12 +71,10 @@ class UserProfileRepositoryImpl implements UserProfileRepository {
   }
 
   @override
-  Future<void> saveWeight(double weight) async {
-    try {
-      await userProfileApiClient.updateUserProfile({'weight': weight});
-    } catch (e) {
-      throw mapToAppException(e);
-    }
+  Future<void> saveWeight(double weight) {
+    return guardApiCall(
+      () => userProfileApiClient.updateUserProfile({'weight': weight}),
+    );
   }
 
   Future<int?> _migrateLocalFtpToBackend() async {

--- a/frontend/lib/data/repository/workout_repository_impl.dart
+++ b/frontend/lib/data/repository/workout_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/data/remote/model/save_workout_result_request.dart';
 import 'package:workoutride/data/remote/workout_remote_data_source.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
@@ -11,34 +12,44 @@ class WorkoutRepositoryImpl implements WorkoutRepository {
 
   WorkoutRepositoryImpl(this._remoteDataSource);
 
+  Future<T> _guard<T>(Future<T> Function() call) async {
+    try {
+      return await call();
+    } catch (e) {
+      throw mapToAppException(e);
+    }
+  }
+
   @override
   Future<List<WorkoutSummary>> getWorkoutSummaries() {
-    return _remoteDataSource.getWorkoutSummaries();
+    return _guard(() => _remoteDataSource.getWorkoutSummaries());
   }
 
   @override
   Future<WorkoutSummary> getWorkoutSummary(int id) {
-    return _remoteDataSource.getWorkoutSummary(id);
+    return _guard(() => _remoteDataSource.getWorkoutSummary(id));
   }
 
   @override
   Future<List<WorkoutBlock>> getWorkoutBlocks(int workoutSummaryId) {
-    return _remoteDataSource.getWorkoutBlocks(workoutSummaryId);
+    return _guard(() => _remoteDataSource.getWorkoutBlocks(workoutSummaryId));
   }
 
   @override
   Future<List<WorkoutResult>> getWorkoutResults() {
-    return _remoteDataSource.getWorkoutResults();
+    return _guard(() => _remoteDataSource.getWorkoutResults());
   }
 
   @override
   Future<WorkoutResult> getWorkoutResult(int id) {
-    return _remoteDataSource.getWorkoutResult(id);
+    return _guard(() => _remoteDataSource.getWorkoutResult(id));
   }
 
   @override
   Future<WorkoutResult> saveWorkoutResult(WorkoutResultDraft draft) {
-    return _remoteDataSource.saveWorkoutResult(_toRequest(draft));
+    return _guard(
+      () => _remoteDataSource.saveWorkoutResult(_toRequest(draft)),
+    );
   }
 
   /// ドメインの Draft を API DTO へ変換する（ISO8601 文字列化を含む）。

--- a/frontend/lib/data/repository/workout_repository_impl.dart
+++ b/frontend/lib/data/repository/workout_repository_impl.dart
@@ -12,42 +12,36 @@ class WorkoutRepositoryImpl implements WorkoutRepository {
 
   WorkoutRepositoryImpl(this._remoteDataSource);
 
-  Future<T> _guard<T>(Future<T> Function() call) async {
-    try {
-      return await call();
-    } catch (e) {
-      throw mapToAppException(e);
-    }
-  }
-
   @override
   Future<List<WorkoutSummary>> getWorkoutSummaries() {
-    return _guard(() => _remoteDataSource.getWorkoutSummaries());
+    return guardApiCall(() => _remoteDataSource.getWorkoutSummaries());
   }
 
   @override
   Future<WorkoutSummary> getWorkoutSummary(int id) {
-    return _guard(() => _remoteDataSource.getWorkoutSummary(id));
+    return guardApiCall(() => _remoteDataSource.getWorkoutSummary(id));
   }
 
   @override
   Future<List<WorkoutBlock>> getWorkoutBlocks(int workoutSummaryId) {
-    return _guard(() => _remoteDataSource.getWorkoutBlocks(workoutSummaryId));
+    return guardApiCall(
+      () => _remoteDataSource.getWorkoutBlocks(workoutSummaryId),
+    );
   }
 
   @override
   Future<List<WorkoutResult>> getWorkoutResults() {
-    return _guard(() => _remoteDataSource.getWorkoutResults());
+    return guardApiCall(() => _remoteDataSource.getWorkoutResults());
   }
 
   @override
   Future<WorkoutResult> getWorkoutResult(int id) {
-    return _guard(() => _remoteDataSource.getWorkoutResult(id));
+    return guardApiCall(() => _remoteDataSource.getWorkoutResult(id));
   }
 
   @override
   Future<WorkoutResult> saveWorkoutResult(WorkoutResultDraft draft) {
-    return _guard(
+    return guardApiCall(
       () => _remoteDataSource.saveWorkoutResult(_toRequest(draft)),
     );
   }

--- a/frontend/lib/domain/model/error/app_exception.dart
+++ b/frontend/lib/domain/model/error/app_exception.dart
@@ -21,4 +21,12 @@ class AppException with _$AppException implements Exception {
         server: (_) => 'サーバーでエラーが発生しました。しばらくしてから再度お試しください。',
         unknown: (message) => 'エラーが発生しました。しばらくしてから再度お試しください。',
       );
+
+  /// UI層はdata層のマッパーに依存できないため、この静的メソッド経由で
+  /// 任意の例外からユーザー向けメッセージを取得する。
+  /// [error]が[AppException]でなければ（data層でのマッピング漏れ）汎用メッセージを返す。
+  static String messageFor(Object error) {
+    if (error is AppException) return error.userMessage;
+    return 'エラーが発生しました。しばらくしてから再度お試しください。';
+  }
 }

--- a/frontend/lib/domain/model/error/app_exception.dart
+++ b/frontend/lib/domain/model/error/app_exception.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_exception.freezed.dart';
+
+/// アプリ全体で使う分類済み例外。DioExceptionなどの外部例外は
+/// data層のマッパー（[mapToAppException]）でこの型に変換してから
+/// domain/uiへ伝播させる。
+@freezed
+class AppException with _$AppException implements Exception {
+  const AppException._();
+
+  const factory AppException.network() = NetworkException;
+  const factory AppException.unauthorized() = UnauthorizedException;
+  const factory AppException.server(int? statusCode) = ServerException;
+  const factory AppException.unknown(String message) = UnknownException;
+
+  /// UIにそのまま表示できる日本語メッセージ。
+  String get userMessage => when(
+        network: () => 'ネットワークに接続できませんでした。通信状況を確認してください。',
+        unauthorized: () => 'ログインの有効期限が切れました。再度ログインしてください。',
+        server: (_) => 'サーバーでエラーが発生しました。しばらくしてから再度お試しください。',
+        unknown: (message) => 'エラーが発生しました。しばらくしてから再度お試しください。',
+      );
+}

--- a/frontend/lib/domain/model/error/app_exception.freezed.dart
+++ b/frontend/lib/domain/model/error/app_exception.freezed.dart
@@ -1,0 +1,637 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_exception.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$AppException {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() network,
+    required TResult Function() unauthorized,
+    required TResult Function(int? statusCode) server,
+    required TResult Function(String message) unknown,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? network,
+    TResult? Function()? unauthorized,
+    TResult? Function(int? statusCode)? server,
+    TResult? Function(String message)? unknown,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? network,
+    TResult Function()? unauthorized,
+    TResult Function(int? statusCode)? server,
+    TResult Function(String message)? unknown,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NetworkException value) network,
+    required TResult Function(UnauthorizedException value) unauthorized,
+    required TResult Function(ServerException value) server,
+    required TResult Function(UnknownException value) unknown,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NetworkException value)? network,
+    TResult? Function(UnauthorizedException value)? unauthorized,
+    TResult? Function(ServerException value)? server,
+    TResult? Function(UnknownException value)? unknown,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NetworkException value)? network,
+    TResult Function(UnauthorizedException value)? unauthorized,
+    TResult Function(ServerException value)? server,
+    TResult Function(UnknownException value)? unknown,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppExceptionCopyWith<$Res> {
+  factory $AppExceptionCopyWith(
+          AppException value, $Res Function(AppException) then) =
+      _$AppExceptionCopyWithImpl<$Res, AppException>;
+}
+
+/// @nodoc
+class _$AppExceptionCopyWithImpl<$Res, $Val extends AppException>
+    implements $AppExceptionCopyWith<$Res> {
+  _$AppExceptionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$NetworkExceptionImplCopyWith<$Res> {
+  factory _$$NetworkExceptionImplCopyWith(_$NetworkExceptionImpl value,
+          $Res Function(_$NetworkExceptionImpl) then) =
+      __$$NetworkExceptionImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$NetworkExceptionImplCopyWithImpl<$Res>
+    extends _$AppExceptionCopyWithImpl<$Res, _$NetworkExceptionImpl>
+    implements _$$NetworkExceptionImplCopyWith<$Res> {
+  __$$NetworkExceptionImplCopyWithImpl(_$NetworkExceptionImpl _value,
+      $Res Function(_$NetworkExceptionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$NetworkExceptionImpl extends NetworkException {
+  const _$NetworkExceptionImpl() : super._();
+
+  @override
+  String toString() {
+    return 'AppException.network()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$NetworkExceptionImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() network,
+    required TResult Function() unauthorized,
+    required TResult Function(int? statusCode) server,
+    required TResult Function(String message) unknown,
+  }) {
+    return network();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? network,
+    TResult? Function()? unauthorized,
+    TResult? Function(int? statusCode)? server,
+    TResult? Function(String message)? unknown,
+  }) {
+    return network?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? network,
+    TResult Function()? unauthorized,
+    TResult Function(int? statusCode)? server,
+    TResult Function(String message)? unknown,
+    required TResult orElse(),
+  }) {
+    if (network != null) {
+      return network();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NetworkException value) network,
+    required TResult Function(UnauthorizedException value) unauthorized,
+    required TResult Function(ServerException value) server,
+    required TResult Function(UnknownException value) unknown,
+  }) {
+    return network(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NetworkException value)? network,
+    TResult? Function(UnauthorizedException value)? unauthorized,
+    TResult? Function(ServerException value)? server,
+    TResult? Function(UnknownException value)? unknown,
+  }) {
+    return network?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NetworkException value)? network,
+    TResult Function(UnauthorizedException value)? unauthorized,
+    TResult Function(ServerException value)? server,
+    TResult Function(UnknownException value)? unknown,
+    required TResult orElse(),
+  }) {
+    if (network != null) {
+      return network(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NetworkException extends AppException {
+  const factory NetworkException() = _$NetworkExceptionImpl;
+  const NetworkException._() : super._();
+}
+
+/// @nodoc
+abstract class _$$UnauthorizedExceptionImplCopyWith<$Res> {
+  factory _$$UnauthorizedExceptionImplCopyWith(
+          _$UnauthorizedExceptionImpl value,
+          $Res Function(_$UnauthorizedExceptionImpl) then) =
+      __$$UnauthorizedExceptionImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UnauthorizedExceptionImplCopyWithImpl<$Res>
+    extends _$AppExceptionCopyWithImpl<$Res, _$UnauthorizedExceptionImpl>
+    implements _$$UnauthorizedExceptionImplCopyWith<$Res> {
+  __$$UnauthorizedExceptionImplCopyWithImpl(_$UnauthorizedExceptionImpl _value,
+      $Res Function(_$UnauthorizedExceptionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$UnauthorizedExceptionImpl extends UnauthorizedException {
+  const _$UnauthorizedExceptionImpl() : super._();
+
+  @override
+  String toString() {
+    return 'AppException.unauthorized()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UnauthorizedExceptionImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() network,
+    required TResult Function() unauthorized,
+    required TResult Function(int? statusCode) server,
+    required TResult Function(String message) unknown,
+  }) {
+    return unauthorized();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? network,
+    TResult? Function()? unauthorized,
+    TResult? Function(int? statusCode)? server,
+    TResult? Function(String message)? unknown,
+  }) {
+    return unauthorized?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? network,
+    TResult Function()? unauthorized,
+    TResult Function(int? statusCode)? server,
+    TResult Function(String message)? unknown,
+    required TResult orElse(),
+  }) {
+    if (unauthorized != null) {
+      return unauthorized();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NetworkException value) network,
+    required TResult Function(UnauthorizedException value) unauthorized,
+    required TResult Function(ServerException value) server,
+    required TResult Function(UnknownException value) unknown,
+  }) {
+    return unauthorized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NetworkException value)? network,
+    TResult? Function(UnauthorizedException value)? unauthorized,
+    TResult? Function(ServerException value)? server,
+    TResult? Function(UnknownException value)? unknown,
+  }) {
+    return unauthorized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NetworkException value)? network,
+    TResult Function(UnauthorizedException value)? unauthorized,
+    TResult Function(ServerException value)? server,
+    TResult Function(UnknownException value)? unknown,
+    required TResult orElse(),
+  }) {
+    if (unauthorized != null) {
+      return unauthorized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnauthorizedException extends AppException {
+  const factory UnauthorizedException() = _$UnauthorizedExceptionImpl;
+  const UnauthorizedException._() : super._();
+}
+
+/// @nodoc
+abstract class _$$ServerExceptionImplCopyWith<$Res> {
+  factory _$$ServerExceptionImplCopyWith(_$ServerExceptionImpl value,
+          $Res Function(_$ServerExceptionImpl) then) =
+      __$$ServerExceptionImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int? statusCode});
+}
+
+/// @nodoc
+class __$$ServerExceptionImplCopyWithImpl<$Res>
+    extends _$AppExceptionCopyWithImpl<$Res, _$ServerExceptionImpl>
+    implements _$$ServerExceptionImplCopyWith<$Res> {
+  __$$ServerExceptionImplCopyWithImpl(
+      _$ServerExceptionImpl _value, $Res Function(_$ServerExceptionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? statusCode = freezed,
+  }) {
+    return _then(_$ServerExceptionImpl(
+      freezed == statusCode
+          ? _value.statusCode
+          : statusCode // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ServerExceptionImpl extends ServerException {
+  const _$ServerExceptionImpl(this.statusCode) : super._();
+
+  @override
+  final int? statusCode;
+
+  @override
+  String toString() {
+    return 'AppException.server(statusCode: $statusCode)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ServerExceptionImpl &&
+            (identical(other.statusCode, statusCode) ||
+                other.statusCode == statusCode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, statusCode);
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ServerExceptionImplCopyWith<_$ServerExceptionImpl> get copyWith =>
+      __$$ServerExceptionImplCopyWithImpl<_$ServerExceptionImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() network,
+    required TResult Function() unauthorized,
+    required TResult Function(int? statusCode) server,
+    required TResult Function(String message) unknown,
+  }) {
+    return server(statusCode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? network,
+    TResult? Function()? unauthorized,
+    TResult? Function(int? statusCode)? server,
+    TResult? Function(String message)? unknown,
+  }) {
+    return server?.call(statusCode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? network,
+    TResult Function()? unauthorized,
+    TResult Function(int? statusCode)? server,
+    TResult Function(String message)? unknown,
+    required TResult orElse(),
+  }) {
+    if (server != null) {
+      return server(statusCode);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NetworkException value) network,
+    required TResult Function(UnauthorizedException value) unauthorized,
+    required TResult Function(ServerException value) server,
+    required TResult Function(UnknownException value) unknown,
+  }) {
+    return server(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NetworkException value)? network,
+    TResult? Function(UnauthorizedException value)? unauthorized,
+    TResult? Function(ServerException value)? server,
+    TResult? Function(UnknownException value)? unknown,
+  }) {
+    return server?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NetworkException value)? network,
+    TResult Function(UnauthorizedException value)? unauthorized,
+    TResult Function(ServerException value)? server,
+    TResult Function(UnknownException value)? unknown,
+    required TResult orElse(),
+  }) {
+    if (server != null) {
+      return server(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ServerException extends AppException {
+  const factory ServerException(final int? statusCode) = _$ServerExceptionImpl;
+  const ServerException._() : super._();
+
+  int? get statusCode;
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ServerExceptionImplCopyWith<_$ServerExceptionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$UnknownExceptionImplCopyWith<$Res> {
+  factory _$$UnknownExceptionImplCopyWith(_$UnknownExceptionImpl value,
+          $Res Function(_$UnknownExceptionImpl) then) =
+      __$$UnknownExceptionImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$UnknownExceptionImplCopyWithImpl<$Res>
+    extends _$AppExceptionCopyWithImpl<$Res, _$UnknownExceptionImpl>
+    implements _$$UnknownExceptionImplCopyWith<$Res> {
+  __$$UnknownExceptionImplCopyWithImpl(_$UnknownExceptionImpl _value,
+      $Res Function(_$UnknownExceptionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$UnknownExceptionImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UnknownExceptionImpl extends UnknownException {
+  const _$UnknownExceptionImpl(this.message) : super._();
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'AppException.unknown(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UnknownExceptionImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UnknownExceptionImplCopyWith<_$UnknownExceptionImpl> get copyWith =>
+      __$$UnknownExceptionImplCopyWithImpl<_$UnknownExceptionImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() network,
+    required TResult Function() unauthorized,
+    required TResult Function(int? statusCode) server,
+    required TResult Function(String message) unknown,
+  }) {
+    return unknown(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? network,
+    TResult? Function()? unauthorized,
+    TResult? Function(int? statusCode)? server,
+    TResult? Function(String message)? unknown,
+  }) {
+    return unknown?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? network,
+    TResult Function()? unauthorized,
+    TResult Function(int? statusCode)? server,
+    TResult Function(String message)? unknown,
+    required TResult orElse(),
+  }) {
+    if (unknown != null) {
+      return unknown(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NetworkException value) network,
+    required TResult Function(UnauthorizedException value) unauthorized,
+    required TResult Function(ServerException value) server,
+    required TResult Function(UnknownException value) unknown,
+  }) {
+    return unknown(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NetworkException value)? network,
+    TResult? Function(UnauthorizedException value)? unauthorized,
+    TResult? Function(ServerException value)? server,
+    TResult? Function(UnknownException value)? unknown,
+  }) {
+    return unknown?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NetworkException value)? network,
+    TResult Function(UnauthorizedException value)? unauthorized,
+    TResult Function(ServerException value)? server,
+    TResult Function(UnknownException value)? unknown,
+    required TResult orElse(),
+  }) {
+    if (unknown != null) {
+      return unknown(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class UnknownException extends AppException {
+  const factory UnknownException(final String message) = _$UnknownExceptionImpl;
+  const UnknownException._() : super._();
+
+  String get message;
+
+  /// Create a copy of AppException
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UnknownExceptionImplCopyWith<_$UnknownExceptionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/frontend/lib/ui/auth/login_screen.dart
+++ b/frontend/lib/ui/auth/login_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 import 'package:workoutride/ui/auth/auth_state_notifier.dart';
 
 class LoginScreen extends ConsumerWidget {
@@ -57,7 +57,7 @@ class LoginScreen extends ConsumerWidget {
     if (error.toString().toLowerCase().contains('cancel')) {
       return 'ログインがキャンセルされました。';
     }
-    return mapToAppException(error).userMessage;
+    return AppException.messageFor(error);
   }
 
   Widget _buildErrorContent(BuildContext context, WidgetRef ref, Object error) {

--- a/frontend/lib/ui/auth/login_screen.dart
+++ b/frontend/lib/ui/auth/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/ui/auth/auth_state_notifier.dart';
 
@@ -53,16 +54,10 @@ class LoginScreen extends ConsumerWidget {
   }
 
   String _friendlyErrorMessage(dynamic error) {
-    final msg = error.toString().toLowerCase();
-    if (msg.contains('network') ||
-        msg.contains('socket') ||
-        msg.contains('connection')) {
-      return 'ネットワークエラーが発生しました。通信状況を確認してください。';
-    }
-    if (msg.contains('cancel') || msg.contains('cancelled')) {
+    if (error.toString().toLowerCase().contains('cancel')) {
       return 'ログインがキャンセルされました。';
     }
-    return 'ログインに失敗しました。しばらくしてから再試行してください。';
+    return mapToAppException(error).userMessage;
   }
 
   Widget _buildErrorContent(BuildContext context, WidgetRef ref, Object error) {

--- a/frontend/lib/ui/history/history_screen_state_notifier.dart
+++ b/frontend/lib/ui/history/history_screen_state_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/domain/model/workout/workout_result.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
@@ -40,7 +41,7 @@ class HistoryScreenStateNotifier extends _$HistoryScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: e.toString(),
+        errorMessage: mapToAppException(e).userMessage,
       );
     }
   }

--- a/frontend/lib/ui/history/history_screen_state_notifier.dart
+++ b/frontend/lib/ui/history/history_screen_state_notifier.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 import 'package:workoutride/domain/model/workout/workout_result.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
 
@@ -41,7 +41,7 @@ class HistoryScreenStateNotifier extends _$HistoryScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: mapToAppException(e).userMessage,
+        errorMessage: AppException.messageFor(e),
       );
     }
   }

--- a/frontend/lib/ui/history/history_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/history/history_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'history_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$historyScreenStateNotifierHash() =>
-    r'435b066956ce64b50ae2e968bd4342b540456b45';
+    r'eeee2d19bf294046fc5d06a77a3423b68912a62a';
 
 /// See also [HistoryScreenStateNotifier].
 @ProviderFor(HistoryScreenStateNotifier)

--- a/frontend/lib/ui/history/history_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/history/history_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'history_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$historyScreenStateNotifierHash() =>
-    r'eeee2d19bf294046fc5d06a77a3423b68912a62a';
+    r'f98f6c3cd4fea5f5f92d4f8ce98303485d1d4ced';
 
 /// See also [HistoryScreenStateNotifier].
 @ProviderFor(HistoryScreenStateNotifier)

--- a/frontend/lib/ui/home/home_screen_state_notifier.dart
+++ b/frontend/lib/ui/home/home_screen_state_notifier.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 import 'package:workoutride/domain/model/workout/workout_summary.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
 import 'package:workoutride/domain/usecase/auto_connect_ble_power_meter_use_case.dart';
@@ -51,7 +51,7 @@ class HomeScreenStateNotifier extends _$HomeScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: mapToAppException(e).userMessage,
+        errorMessage: AppException.messageFor(e),
       );
     }
   }

--- a/frontend/lib/ui/home/home_screen_state_notifier.dart
+++ b/frontend/lib/ui/home/home_screen_state_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/domain/model/workout/workout_summary.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
@@ -50,7 +51,7 @@ class HomeScreenStateNotifier extends _$HomeScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: e.toString(),
+        errorMessage: mapToAppException(e).userMessage,
       );
     }
   }

--- a/frontend/lib/ui/home/home_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/home/home_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'home_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$homeScreenStateNotifierHash() =>
-    r'42027c87acb129c788a2dc311e1f2deac18243b9';
+    r'9a841ef11e0f1cf2cc33845b405959a92cda3c6f';
 
 /// See also [HomeScreenStateNotifier].
 @ProviderFor(HomeScreenStateNotifier)

--- a/frontend/lib/ui/home/home_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/home/home_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'home_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$homeScreenStateNotifierHash() =>
-    r'9a841ef11e0f1cf2cc33845b405959a92cda3c6f';
+    r'28ea9992d401a30923145ba67440a6518a7c1c0f';
 
 /// See also [HomeScreenStateNotifier].
 @ProviderFor(HomeScreenStateNotifier)

--- a/frontend/lib/ui/settings/ftp_registration_dialog.dart
+++ b/frontend/lib/ui/settings/ftp_registration_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 
 class FtpRegistrationDialog extends ConsumerStatefulWidget {
   const FtpRegistrationDialog({super.key});
@@ -51,7 +52,7 @@ class _FtpRegistrationDialogState extends ConsumerState<FtpRegistrationDialog> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('FTPの保存に失敗しました: $e')),
+          SnackBar(content: Text(AppException.messageFor(e))),
         );
       }
     } finally {

--- a/frontend/lib/ui/settings/settings_screen_state_notifier.dart
+++ b/frontend/lib/ui/settings/settings_screen_state_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
 
 part 'settings_screen_state_notifier.freezed.dart';
@@ -35,7 +36,7 @@ class SettingsScreenStateNotifier extends _$SettingsScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: 'Failed to load user profile',
+        errorMessage: mapToAppException(e).userMessage,
       );
     }
   }
@@ -54,7 +55,7 @@ class SettingsScreenStateNotifier extends _$SettingsScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: 'Failed to save weight',
+        errorMessage: mapToAppException(e).userMessage,
       );
     }
   }

--- a/frontend/lib/ui/settings/settings_screen_state_notifier.dart
+++ b/frontend/lib/ui/settings/settings_screen_state_notifier.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 
 part 'settings_screen_state_notifier.freezed.dart';
 part 'settings_screen_state_notifier.g.dart';
@@ -36,7 +36,7 @@ class SettingsScreenStateNotifier extends _$SettingsScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: mapToAppException(e).userMessage,
+        errorMessage: AppException.messageFor(e),
       );
     }
   }
@@ -55,7 +55,7 @@ class SettingsScreenStateNotifier extends _$SettingsScreenStateNotifier {
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: mapToAppException(e).userMessage,
+        errorMessage: AppException.messageFor(e),
       );
     }
   }

--- a/frontend/lib/ui/settings/settings_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/settings/settings_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'settings_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$settingsScreenStateNotifierHash() =>
-    r'e8bb1684093f23ebe8369e29efc09f2919b4e751';
+    r'4a924c4f79260558992b81902830db792d413993';
 
 /// See also [SettingsScreenStateNotifier].
 @ProviderFor(SettingsScreenStateNotifier)

--- a/frontend/lib/ui/settings/settings_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/settings/settings_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'settings_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$settingsScreenStateNotifierHash() =>
-    r'4a924c4f79260558992b81902830db792d413993';
+    r'e9d350abe6df04cde812aef83785f3f50f089460';
 
 /// See also [SettingsScreenStateNotifier].
 @ProviderFor(SettingsScreenStateNotifier)

--- a/frontend/lib/ui/settings/weight_registration_dialog.dart
+++ b/frontend/lib/ui/settings/weight_registration_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 
 class WeightRegistrationDialog extends ConsumerStatefulWidget {
   final double? currentWeight;
@@ -55,7 +56,7 @@ class _WeightRegistrationDialogState
         Navigator.of(context).pop(weight);
       }
     } catch (e) {
-      _showErrorDialog('体重の保存に失敗しました');
+      _showErrorDialog(AppException.messageFor(e));
     } finally {
       if (mounted) {
         setState(() {

--- a/frontend/lib/ui/workout/workout_screen_state_notifier.dart
+++ b/frontend/lib/ui/workout/workout_screen_state_notifier.dart
@@ -3,8 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:workoutride/data/audio/workout_sound_player.dart';
-import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/domain/model/power_alert_message.dart';
 import 'package:workoutride/domain/repository/user_profile_repository.dart';
@@ -223,7 +223,7 @@ class WorkoutScreenStateNotifier extends _$WorkoutScreenStateNotifier {
     } catch (e) {
       state = WorkoutScreenUiState(
         isLoading: false,
-        errorMessage: mapToAppException(e).userMessage,
+        errorMessage: AppException.messageFor(e),
         userWeight: _userWeight ?? 60.0,
         userFtp: _userFtp ?? 200,
       );

--- a/frontend/lib/ui/workout/workout_screen_state_notifier.dart
+++ b/frontend/lib/ui/workout/workout_screen_state_notifier.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:workoutride/data/audio/workout_sound_player.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/domain/model/power_alert_message.dart';
@@ -222,7 +223,7 @@ class WorkoutScreenStateNotifier extends _$WorkoutScreenStateNotifier {
     } catch (e) {
       state = WorkoutScreenUiState(
         isLoading: false,
-        errorMessage: e.toString(),
+        errorMessage: mapToAppException(e).userMessage,
         userWeight: _userWeight ?? 60.0,
         userFtp: _userFtp ?? 200,
       );

--- a/frontend/lib/ui/workout/workout_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/workout/workout_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'workout_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$workoutScreenStateNotifierHash() =>
-    r'3d022aed3945c81fb8bfeed4cad7d6275f7c559b';
+    r'7828a9998baeb35447801ca62c63680c4b1a1e24';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/frontend/lib/ui/workout/workout_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/workout/workout_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'workout_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$workoutScreenStateNotifierHash() =>
-    r'82c76ec4379742b507e77c246a4b698ae5d8a06f';
+    r'3d022aed3945c81fb8bfeed4cad7d6275f7c559b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/error/app_exception.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/domain/model/workout/workout_summary.dart';
 import 'package:workoutride/domain/repository/workout_repository.dart';
@@ -65,7 +65,7 @@ class WorkoutDetailScreenStateNotifier
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: mapToAppException(e).userMessage,
+        errorMessage: AppException.messageFor(e),
       );
     }
   }

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:workoutride/data/remote/error/exception_mapper.dart';
 import 'package:workoutride/di/providers.dart';
 import 'package:workoutride/domain/model/workout/workout_block.dart';
 import 'package:workoutride/domain/model/workout/workout_summary.dart';
@@ -64,7 +65,7 @@ class WorkoutDetailScreenStateNotifier
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
-        errorMessage: e.toString(),
+        errorMessage: mapToAppException(e).userMessage,
       );
     }
   }

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'workout_detail_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$workoutDetailScreenStateNotifierHash() =>
-    r'93e6aaf7136d7f78de4dded6f993519955b16b60';
+    r'08b6b6427d254b86bffc5a848ce0690fdebe19f7';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.g.dart
+++ b/frontend/lib/ui/workout_detail/workout_detail_screen_state_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'workout_detail_screen_state_notifier.dart';
 // **************************************************************************
 
 String _$workoutDetailScreenStateNotifierHash() =>
-    r'08b6b6427d254b86bffc5a848ce0690fdebe19f7';
+    r'4ff2a6fcb1db6c388cf90fc9b9618bd6bc46ce9d';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
## Summary
- `AppException`（network/unauthorized/server/unknown）を追加し、DioExceptionを分類してから各ViewModelへ伝播させるようにした
- オフライン時に`e.toString()`の生の例外文言や英語の固定文言がそのままUIに出ていた箇所を、日本語のわかりやすいメッセージに統一
- ログイン画面の文字列マッチによる簡易エラー分類を型ベースの分類に置き換え

## Test plan
- [x] `flutter analyze` — 新規エラーなし（既存のDTO snake_case info等は変更前から存在）
- [x] `flutter test` — 45/45 pass