### PR TITLE
fix: Grape APIに共通のエラーハンドリングを追加

### DIFF
--- a/backend/app/api/v1/root.rb
+++ b/backend/app/api/v1/root.rb
@@ -4,6 +4,26 @@ module V1
     format :json
     content_type :json, 'application/json;charset=UTF-8'
 
+    rescue_from ActiveRecord::RecordNotFound do |_e|
+      error!({ error: 'Not found' }, 404)
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      error!({ error: e.record.errors.full_messages.join(', ') }, 422)
+    end
+
+    # GrapeのバリデーションエラーやHTTPステータス付き例外は自前の情報を保持しているため、
+    # 一段狭いこのハンドラでキャッチしてcatch-all(rescue_from :all)に飲まれないようにする。
+    rescue_from Grape::Exceptions::Base do |e|
+      error!(e.message, e.status)
+    end
+
+    rescue_from :all do |e|
+      Rails.logger.error("[API] Unhandled error: #{e.class} - #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      error!({ error: 'Internal server error' }, 500)
+    end
+
     mount V1::Auth
     mount V1::Workouts
     mount V1::WorkoutResults

--- a/backend/spec/requests/api/v1/error_handling_spec.rb
+++ b/backend/spec/requests/api/v1/error_handling_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'API error handling', type: :request do
+  let(:user) { User.create!(provider: 'google', uid: '12345') }
+  let(:auth_token) { user.auth_tokens.create! }
+  let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
+
+  describe 'ActiveRecord::RecordNotFound' do
+    it 'returns a JSON 404 instead of leaking an HTML error page' do
+      get '/api/v1/workout_summaries/999999', headers: headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.content_type).to match(%r{application/json})
+      expect(JSON.parse(response.body)).to eq('error' => 'Not found')
+    end
+  end
+
+  describe 'ActiveRecord::RecordInvalid' do
+    it 'returns a JSON 422 with the validation message' do
+      post '/api/v1/user_ftps', params: { ftp_value: 0 }, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.content_type).to match(%r{application/json})
+      expect(JSON.parse(response.body)['error']).to be_present
+    end
+  end
+
+  describe 'Grape param validation errors' do
+    it 'still returns 400 for missing required params (not swallowed by the catch-all)' do
+      post '/api/v1/user_ftps', params: {}, headers: headers
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe 'unexpected StandardError' do
+    it 'returns a generic JSON 500 without leaking internals' do
+      allow(WorkoutSummary).to receive(:all).and_raise(StandardError, 'boom')
+
+      get '/api/v1/workout_summaries', headers: headers
+
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.content_type).to match(%r{application/json})
+      json = JSON.parse(response.body)
+      expect(json['error']).to eq('Internal server error')
+      expect(response.body).not_to include('boom')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- rescue_fromが一切なく、想定外の例外（RecordNotFound/RecordInvalid/その他）がRailsのデフォルトのHTML例外ページとして返っていた（JSON契約が崩れる）
- RecordNotFound→404、RecordInvalid→422、Grapeのパラメータバリデーションエラーは元のstatus/messageを維持、それ以外のStandardErrorはログ+Sentry送信の上で汎用500 JSONを返すよう統一

## Test plan
- [x] `bundle exec rspec` — 72/72 pass（新規spec: error_handling_spec.rb 4件追加）