### PR TITLE
fix: config.hostsを有効化し、CORS未設定の理由を明記する

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -78,11 +78,8 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts << "workoutride.ohnaoki.app"
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,8 +1,10 @@
 # Be sure to restart your server when you modify this file.
 
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
-
+# 意図的に未設定: このAPIのクライアントはFlutterアプリ（Android/iOSネイティブ）のみで、
+# ブラウザ上のJSから別オリジンとして呼び出す経路（Web版フロントエンド等）は存在しない。
+# ネイティブHTTPクライアントはブラウザのSame-Origin Policy/CORSの対象外のため、
+# CORS設定なしで問題ない。将来Web版クライアントを追加する場合はここでオリジンを許可する。
+#
 # Read more: https://github.com/cyu/rack-cors
 
 # Rails.application.config.middleware.insert_before 0, Rack::Cors do


### PR DESCRIPTION
## Summary
- `config.hosts`がコメントアウトされたままでDNS rebinding対策が無効だったため、本番ドメイン(workoutride.ohnaoki.app)を許可リストに追加
- kamalのヘルスチェック(/up)はhost_authorizationの対象外に設定
- CORSは検討の結果、クライアントがFlutterネイティブアプリのみのため不要と判断し、その理由をコメントで明記（設定自体の変更なし）

## Test plan
- [x] `bundle exec rspec` — 68/68 pass
- [x] `ruby -c config/environments/production.rb` — syntax OK
- [ ] マージ後、本番デプロイで実際に `workoutride.ohnaoki.app` 経由のアクセスが引き続き通ることを確認（config.hosts設定ミスで本番アクセス不能になるリスクがあるため要目視確認）