### PR TITLE
test: バックエンドのテストカバレッジの穴を埋める

### DIFF
--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    provider { 'google' }
+    sequence(:uid) { |n| "google-uid-#{n}" }
+  end
+end

--- a/backend/spec/models/user_ftp_spec.rb
+++ b/backend/spec/models/user_ftp_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe UserFtp, type: :model do
+  describe 'associations' do
+    it { should belong_to(:user).optional }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:ftp_value) }
+    it { should validate_numericality_of(:ftp_value).is_greater_than(0).is_less_than_or_equal_to(2000) }
+  end
+end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'associations' do
+    it { should have_many(:auth_tokens).dependent(:destroy) }
+    it { should have_many(:workout_results).dependent(:destroy) }
+    it { should have_many(:user_ftps).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:provider) }
+    it { should validate_presence_of(:uid) }
+
+    it 'validates uniqueness of uid scoped to provider' do
+      create(:user, provider: 'google', uid: 'dup-uid')
+      duplicate = build(:user, provider: 'google', uid: 'dup-uid')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:uid]).to be_present
+    end
+
+    it 'allows the same uid across different providers' do
+      create(:user, provider: 'google', uid: 'shared-uid')
+      other_provider = build(:user, provider: 'system', uid: 'shared-uid')
+
+      expect(other_provider).to be_valid
+    end
+  end
+
+  describe '#google?' do
+    it 'returns true for google provider' do
+      expect(build(:user, provider: 'google')).to be_google
+    end
+
+    it 'returns false for other providers' do
+      expect(build(:user, provider: 'system')).not_to be_google
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/user_profile_spec.rb
+++ b/backend/spec/requests/api/v1/user_profile_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe 'V1::UserProfile', type: :request do
+  let(:user) { User.create!(provider: 'google', uid: '12345') }
+  let(:auth_token) { user.auth_tokens.create! }
+  let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
+
+  describe 'GET /v1/user_profile' do
+    context 'when weight is set' do
+      before { user.update!(weight: 65.5) }
+
+      it 'returns the current weight' do
+        get '/api/v1/user_profile', headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['weight']).to eq(65.5)
+      end
+    end
+
+    context 'when weight is not set' do
+      it 'returns nil weight' do
+        get '/api/v1/user_profile', headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['weight']).to be_nil
+      end
+    end
+
+    context 'without authentication' do
+      it 'returns 401' do
+        get '/api/v1/user_profile'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PUT /v1/user_profile' do
+    context 'with a valid weight' do
+      it 'updates the weight' do
+        put '/api/v1/user_profile', params: { weight: 70.2 }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['weight']).to eq(70.2)
+        expect(user.reload.weight).to eq(70.2)
+      end
+    end
+
+    context 'boundary values' do
+      it 'accepts the lower boundary just above 0' do
+        put '/api/v1/user_profile', params: { weight: 0.1 }, headers: headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'accepts the upper boundary of 300' do
+        put '/api/v1/user_profile', params: { weight: 300 }, headers: headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'rejects 0' do
+        put '/api/v1/user_profile', params: { weight: 0 }, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'rejects a negative weight' do
+        put '/api/v1/user_profile', params: { weight: -5 }, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'rejects weight above 300' do
+        put '/api/v1/user_profile', params: { weight: 300.1 }, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'without authentication' do
+      it 'returns 401' do
+        put '/api/v1/user_profile', params: { weight: 70 }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/workout_results_spec.rb
+++ b/backend/spec/requests/api/v1/workout_results_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe 'V1::WorkoutResults', type: :request do
       get "/api/v1/workout_results/#{workout_result.id}"
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it 'does not allow fetching another user\'s workout result' do
+      other_user = User.create!(provider: 'google', uid: 'other-user')
+      other_result = create(:workout_result, workout_summary: workout_summary, user: other_user)
+
+      get "/api/v1/workout_results/#{other_result.id}", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'POST /api/v1/workout_results' do

--- a/backend/spec/services/google_auth_service_spec.rb
+++ b/backend/spec/services/google_auth_service_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe GoogleAuthService do
+  describe '#verify_and_authenticate' do
+    let(:id_token) { 'dummy-id-token' }
+    let(:payload) { { 'sub' => 'google-sub-123' } }
+
+    context 'when the ID token is valid' do
+      before do
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return(payload)
+      end
+
+      context 'and the user does not exist yet' do
+        it 'creates a new user from the token payload' do
+          expect {
+            described_class.new(id_token).verify_and_authenticate
+          }.to change(User, :count).by(1)
+
+          user = User.find_by(provider: 'google', uid: 'google-sub-123')
+          expect(user).to be_present
+        end
+      end
+
+      context 'and the user already exists' do
+        let!(:existing_user) { User.create!(provider: 'google', uid: 'google-sub-123') }
+
+        it 'returns the existing user without creating a duplicate' do
+          expect {
+            described_class.new(id_token).verify_and_authenticate
+          }.not_to change(User, :count)
+
+          expect(described_class.new(id_token).verify_and_authenticate).to eq(existing_user)
+        end
+      end
+    end
+
+    context 'when the ID token is invalid' do
+      before do
+        allow(Google::Auth::IDTokens).to receive(:verify_oidc)
+          .and_raise(Google::Auth::IDTokens::VerificationError, 'bad token')
+      end
+
+      it 'raises a Grape validation error without leaking the underlying error' do
+        expect {
+          described_class.new(id_token).verify_and_authenticate
+        }.to raise_error(Grape::Exceptions::Validation)
+      end
+
+      it 'does not create a user' do
+        expect {
+          begin
+            described_class.new(id_token).verify_and_authenticate
+          rescue Grape::Exceptions::Validation
+            nil
+          end
+        }.not_to change(User, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- UserProfile/GoogleAuthService/User/UserFtpにspecが一件もなかったのを追加
- WorkoutResultsの他ユーザーリソースへのIDORが起きないことを回帰テストで固定
- User/AuthTokenセットアップの重複を`spec/factories/users.rb`としてfactory化（既存specは今回スコープ外）

## Test plan
- [x] `bundle exec rspec` — 95/95 pass（追加前は68件）
- [x] `bundle exec rubocop` on changed files — no offenses