### PR TITLE
feat: workout_summaries/workout_resultsにページネーションを追加

### DIFF
--- a/backend/app/api/v1/workout_results.rb
+++ b/backend/app/api/v1/workout_results.rb
@@ -12,10 +12,14 @@ module V1
       desc 'ワークアウト結果の一覧を取得'
       params do
         optional :workout_summary_id, type: Integer, desc: 'ワークアウトサマリーIDでフィルタ'
+        optional :page, type: Integer, default: 1, values: ->(v) { v >= 1 }, desc: 'ページ番号'
+        optional :per_page, type: Integer, default: 50, values: ->(v) { v.between?(1, 200) }, desc: '1ページあたりの件数(最大200)'
       end
       get do
         results = current_user.workout_results.includes(:workout_block_results).order(created_at: :desc)
         results = results.where(workout_summary_id: params[:workout_summary_id]) if params[:workout_summary_id]
+        header 'X-Total-Count', results.count.to_s
+        results = results.limit(params[:per_page]).offset((params[:page] - 1) * params[:per_page])
         present results, with: Entities::WorkoutResult
       end
 

--- a/backend/app/api/v1/workouts.rb
+++ b/backend/app/api/v1/workouts.rb
@@ -10,8 +10,14 @@ module V1
 
     resource :workout_summaries do
       desc 'ワークアウトサマリーの一覧を取得'
+      params do
+        optional :page, type: Integer, default: 1, values: ->(v) { v >= 1 }, desc: 'ページ番号'
+        optional :per_page, type: Integer, default: 100, values: ->(v) { v.between?(1, 200) }, desc: '1ページあたりの件数(最大200)'
+      end
       get do
-        workout_summaries = WorkoutSummary.all
+        workout_summaries = WorkoutSummary.order(:id)
+        header 'X-Total-Count', workout_summaries.count.to_s
+        workout_summaries = workout_summaries.limit(params[:per_page]).offset((params[:page] - 1) * params[:per_page])
         present workout_summaries, with: Entities::WorkoutSummary
       end
 

--- a/backend/spec/requests/api/v1/workout_results_spec.rb
+++ b/backend/spec/requests/api/v1/workout_results_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe 'V1::WorkoutResults', type: :request do
       get '/api/v1/workout_results'
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it 'paginates results and reports the total via header' do
+      create_list(:workout_result, 3, workout_summary: workout_summary, user: user)
+
+      get '/api/v1/workout_results', params: { per_page: 2 }, headers: headers
+
+      expect(JSON.parse(response.body).size).to eq(2)
+      expect(response.headers['X-Total-Count']).to eq('4')
+    end
   end
 
   describe 'GET /api/v1/workout_results/:id' do

--- a/backend/spec/requests/api/v1/workout_summaries_spec.rb
+++ b/backend/spec/requests/api/v1/workout_summaries_spec.rb
@@ -58,5 +58,30 @@ RSpec.describe 'API::V1::WorkoutSummaries', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'pagination' do
+      let!(:workout_summaries) { create_list(:workout_summary, 5) }
+
+      it 'limits results to per_page and reports the total via header' do
+        get '/api/v1/workout_summaries', params: { per_page: 2 }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(2)
+        expect(response.headers['X-Total-Count']).to eq('5')
+      end
+
+      it 'returns the second page' do
+        get '/api/v1/workout_summaries', params: { page: 2, per_page: 2 }, headers: headers
+
+        ids = JSON.parse(response.body).map { |s| s['id'] }
+        expect(ids).to eq(workout_summaries[2..3].map(&:id))
+      end
+
+      it 'rejects a per_page above the max' do
+        get '/api/v1/workout_summaries', params: { per_page: 201 }, headers: headers
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `GET /workout_summaries`と`GET /workout_results`が無制限に全件返していたのを、page/per_page対応にした（per_page上限200）
- レスポンスボディの配列形状は維持し、総件数はX-Total-Countヘッダで返すため、フロントエンド側の変更は不要（既存の呼び出しはデフォルトのper_page内に収まる）

## Test plan
- [x] `bundle exec rspec` — 72/72 pass