### PR TITLE
fix: user_ftps/workout_resultsのuser_idを必須にする

### DIFF
--- a/backend/app/models/user_ftp.rb
+++ b/backend/app/models/user_ftp.rb
@@ -1,5 +1,5 @@
 class UserFtp < ApplicationRecord
-  belongs_to :user, optional: true
+  belongs_to :user
 
   validates :ftp_value, presence: true, numericality: { greater_than: 0, less_than_or_equal_to: 2000 }
 end

--- a/backend/app/models/workout_result.rb
+++ b/backend/app/models/workout_result.rb
@@ -1,5 +1,5 @@
 class WorkoutResult < ApplicationRecord
-  belongs_to :user, optional: true
+  belongs_to :user
   belongs_to :workout_summary
   has_many :workout_block_results, dependent: :destroy
 

--- a/backend/db/migrate/20260805124031_make_user_id_required_on_user_ftps_and_workout_results.rb
+++ b/backend/db/migrate/20260805124031_make_user_id_required_on_user_ftps_and_workout_results.rb
@@ -1,0 +1,14 @@
+class MakeUserIdRequiredOnUserFtpsAndWorkoutResults < ActiveRecord::Migration[8.0]
+  def up
+    raise 'user_ftps has rows with null user_id' if UserFtp.where(user_id: nil).exists?
+    raise 'workout_results has rows with null user_id' if WorkoutResult.where(user_id: nil).exists?
+
+    change_column_null :user_ftps, :user_id, false
+    change_column_null :workout_results, :user_id, false
+  end
+
+  def down
+    change_column_null :user_ftps, :user_id, true
+    change_column_null :workout_results, :user_id, true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_12_090000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_05_124031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -30,7 +30,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_090000) do
     t.integer "ftp_value", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id", "created_at"], name: "index_user_ftps_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_user_ftps_on_user_id"
   end
@@ -79,7 +79,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_090000) do
     t.string "status", default: "completed", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_workout_results_on_user_id"
     t.index ["workout_summary_id"], name: "index_workout_results_on_workout_summary_id"
   end

--- a/backend/spec/models/user_ftp_spec.rb
+++ b/backend/spec/models/user_ftp_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UserFtp, type: :model do
   describe 'associations' do
-    it { should belong_to(:user).optional }
+    it { should belong_to(:user) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
## Summary
- `UserFtp`/`WorkoutResult`の`belongs_to :user`が`optional: true`、DBのuser_idカラムもnullable のままで、実際は必ずユーザーに紐付くのにモデル/DBどちらでも強制されていなかった
- 本番DBを事前確認し、両テーブルとも`user_id IS NULL`の行が0件であることを確認済み（マイグレーションのup側でも同条件をガード）
- `belongs_to :user`を必須化 + DBにNOT NULL制約を追加

## Test plan
- [x] `bundle exec rspec` — 99/99 pass
- [x] 本番DBで事前にnull件数0件を確認済み（`docker exec ... rails runner`で確認）

**注意**: 本番マイグレーションが伴います（次回mainへのマージ時にkamalのdb:prepareで自動適用）。事前確認済みなので安全と判断していますが、念のため共有します。