### PR TITLE
refactor: 認証パターンを他のエンドポイントと統一する

### DIFF
--- a/backend/app/api/helpers/auth_helper.rb
+++ b/backend/app/api/helpers/auth_helper.rb
@@ -8,6 +8,11 @@ module Helpers
       @current_user ||= authenticate_from_token
     end
 
+    def current_auth_token
+      current_user
+      @current_auth_token
+    end
+
     private
 
     def authenticate_from_token
@@ -18,6 +23,7 @@ module Helpers
       return nil unless auth_token
 
       auth_token.touch_last_used!
+      @current_auth_token = auth_token
       auth_token.user
     end
 

--- a/backend/app/api/v1/auth.rb
+++ b/backend/app/api/v1/auth.rb
@@ -24,29 +24,31 @@ module V1
         }
       end
 
-      desc 'Sign out'
-      delete :logout do
-        authenticate!
-        token = extract_token_from_header
-        current_user.auth_tokens.find_by(token_digest: AuthToken.digest(token))&.destroy
-        { message: 'Logged out successfully' }
-      end
+      namespace '' do
+        before do
+          authenticate!
+        end
 
-      desc 'Delete account and all associated data'
-      delete :account do
-        authenticate!
-        current_user.destroy!
-        { message: 'Account deleted successfully' }
-      end
+        desc 'Sign out'
+        delete :logout do
+          current_auth_token&.destroy
+          { message: 'Logged out successfully' }
+        end
 
-      desc 'Get current user'
-      get :me do
-        authenticate!
-        {
-          id: current_user.id,
-          provider: current_user.provider,
-          uid: current_user.uid
-        }
+        desc 'Delete account and all associated data'
+        delete :account do
+          current_user.destroy!
+          { message: 'Account deleted successfully' }
+        end
+
+        desc 'Get current user'
+        get :me do
+          {
+            id: current_user.id,
+            provider: current_user.provider,
+            uid: current_user.uid
+          }
+        end
       end
     end
   end

--- a/backend/spec/requests/api/v1/auth_spec.rb
+++ b/backend/spec/requests/api/v1/auth_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe 'V1::Auth', type: :request do
   let!(:auth_token) { user.auth_tokens.create! }
   let(:headers) { { 'Authorization' => "Bearer #{auth_token.token}" } }
 
+  describe 'POST /v1/auth/google' do
+    it 'signs in without requiring an Authorization header' do
+      allow(Google::Auth::IDTokens).to receive(:verify_oidc).and_return('sub' => 'new-google-sub')
+
+      post '/api/v1/auth/google', params: { id_token: 'dummy-token' }
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json['token']).to be_present
+      expect(json['user']['uid']).to eq('new-google-sub')
+    end
+  end
+
   describe 'DELETE /v1/auth/account' do
     let(:workout_summary) { create(:workout_summary) }
 


### PR DESCRIPTION
## Summary
- auth.rbだけ各ルートで個別に`authenticate!`を呼ぶ方式だったのを、他4ファイルと同じ`before do authenticate! end`パターンに統一（`POST :google`のみ`namespace ''`の外側に残し未認証のまま維持）
- `logout`がトークンを二重にDBルックアップしていたのを、`AuthHelper`に`current_auth_token`を追加してメモ化済みのものを再利用するよう修正
- `POST /auth/google`を直接叩くrequest specを追加（これまで無かった）

## Test plan
- [x] `bundle exec rspec` — 100/100 pass