### PR TITLE
feat: category/block_typeをベタ文字列からcategories/block_categoriesテーブルに正規化

### DIFF
--- a/backend/app/api/entities/workout_block.rb
+++ b/backend/app/api/entities/workout_block.rb
@@ -5,7 +5,9 @@ module Entities
     expose :order_index
     expose :target_ftp_percentage
     expose :duration
-    expose :block_type
+    expose :block_type, documentation: { desc: 'ブロックカテゴリ名' } do |block|
+      block.block_category.name
+    end
     expose :created_at
     expose :updated_at
   end

--- a/backend/app/api/entities/workout_summary.rb
+++ b/backend/app/api/entities/workout_summary.rb
@@ -3,7 +3,9 @@ module Entities
     expose :id
     expose :name
     expose :total_duration
-    expose :category
+    expose :category, documentation: { desc: 'カテゴリ名' } do |summary|
+      summary.category.name
+    end
     expose :created_at
     expose :updated_at
   end

--- a/backend/app/api/v1/workouts.rb
+++ b/backend/app/api/v1/workouts.rb
@@ -15,7 +15,7 @@ module V1
         optional :per_page, type: Integer, default: 100, values: ->(v) { v.between?(1, 200) }, desc: '1ページあたりの件数(最大200)'
       end
       get do
-        workout_summaries = WorkoutSummary.order(:id)
+        workout_summaries = WorkoutSummary.includes(:category).order(:id)
         header 'X-Total-Count', workout_summaries.count.to_s
         workout_summaries = workout_summaries.limit(params[:per_page]).offset((params[:page] - 1) * params[:per_page])
         present workout_summaries, with: Entities::WorkoutSummary
@@ -37,7 +37,7 @@ module V1
         requires :id, type: Integer, desc: 'ワークアウトサマリーID'
       end
       get ':id' do
-        workout_blocks = WorkoutBlock.where(workout_summary_id: params[:id])
+        workout_blocks = WorkoutBlock.includes(:block_category).where(workout_summary_id: params[:id])
         present workout_blocks, with: Entities::WorkoutBlock
       end
     end

--- a/backend/app/models/block_category.rb
+++ b/backend/app/models/block_category.rb
@@ -1,0 +1,5 @@
+class BlockCategory < ApplicationRecord
+  has_many :workout_blocks, dependent: :restrict_with_exception
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+  has_many :workout_summaries, dependent: :restrict_with_exception
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/backend/app/models/workout_block.rb
+++ b/backend/app/models/workout_block.rb
@@ -1,6 +1,7 @@
 class WorkoutBlock < ApplicationRecord
   belongs_to :workout_summary
-  
+  belongs_to :block_category
+
   # order_indexカラムでソートするデフォルトスコープを追加
   default_scope { order(:order_index) }
 end

--- a/backend/app/models/workout_summary.rb
+++ b/backend/app/models/workout_summary.rb
@@ -1,4 +1,6 @@
 class WorkoutSummary < ApplicationRecord
+  belongs_to :category
+
   has_many :workout_blocks, dependent: :destroy
   has_many :workout_results, dependent: :destroy
 end

--- a/backend/db/migrate/20260805125126_create_categories.rb
+++ b/backend/db/migrate/20260805125126_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :categories, :name, unique: true
+  end
+end

--- a/backend/db/migrate/20260805125127_create_block_categories.rb
+++ b/backend/db/migrate/20260805125127_create_block_categories.rb
@@ -1,0 +1,10 @@
+class CreateBlockCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :block_categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :block_categories, :name, unique: true
+  end
+end

--- a/backend/db/migrate/20260805125211_normalize_category_columns.rb
+++ b/backend/db/migrate/20260805125211_normalize_category_columns.rb
@@ -1,0 +1,70 @@
+class NormalizeCategoryColumns < ActiveRecord::Migration[8.0]
+  # マイグレーション内では本体のモデル定義に依存せず、専用のAR継承クラスを使う。
+  class MigrationCategory < ActiveRecord::Base
+    self.table_name = "categories"
+  end
+
+  class MigrationBlockCategory < ActiveRecord::Base
+    self.table_name = "block_categories"
+  end
+
+  class MigrationWorkoutSummary < ActiveRecord::Base
+    self.table_name = "workout_summaries"
+  end
+
+  class MigrationWorkoutBlock < ActiveRecord::Base
+    self.table_name = "workout_blocks"
+  end
+
+  def up
+    add_reference :workout_summaries, :category, foreign_key: true
+    add_reference :workout_blocks, :block_category, foreign_key: true
+
+    MigrationWorkoutSummary.reset_column_information
+    MigrationWorkoutSummary.find_each do |summary|
+      next if summary.category.blank?
+
+      category = MigrationCategory.find_or_create_by!(name: summary.category)
+      summary.update_column(:category_id, category.id)
+    end
+
+    # block_typeは「メインセット1」のようにカテゴリ名+連番が混在しているため、
+    # 末尾の数字・ハイフンを除いた部分を真のカテゴリとして正規化する。
+    MigrationWorkoutBlock.reset_column_information
+    MigrationWorkoutBlock.find_each do |block|
+      next if block.block_type.blank?
+
+      base_name = block.block_type.sub(/[\d\-]+\z/, "")
+      block_category = MigrationBlockCategory.find_or_create_by!(name: base_name)
+      block.update_column(:block_category_id, block_category.id)
+    end
+
+    change_column_null :workout_summaries, :category_id, false
+    change_column_null :workout_blocks, :block_category_id, false
+
+    remove_column :workout_summaries, :category
+    remove_column :workout_blocks, :block_type
+  end
+
+  def down
+    add_column :workout_summaries, :category, :string
+    add_column :workout_blocks, :block_type, :string
+
+    MigrationWorkoutSummary.reset_column_information
+    MigrationWorkoutSummary.find_each do |summary|
+      category = MigrationCategory.find_by(id: summary.category_id)
+      summary.update_column(:category, category&.name)
+    end
+
+    # 注意: block_typeに埋め込まれていた連番(「インターバル1」等)は正規化時に破棄しているため、
+    # ロールバックしてもカテゴリ名のみ（連番なし）しか復元できない。
+    MigrationWorkoutBlock.reset_column_information
+    MigrationWorkoutBlock.find_each do |block|
+      block_category = MigrationBlockCategory.find_by(id: block.block_category_id)
+      block.update_column(:block_type, block_category&.name)
+    end
+
+    remove_reference :workout_summaries, :category, foreign_key: true
+    remove_reference :workout_blocks, :block_category, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_05_124031) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_05_125211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,20 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_05_124031) do
     t.index ["token_digest"], name: "index_auth_tokens_on_token_digest", unique: true
     t.index ["user_id", "expires_at"], name: "index_auth_tokens_on_user_id_and_expires_at"
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
+  end
+
+  create_table "block_categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_block_categories_on_name", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
   create_table "user_ftps", force: :cascade do |t|
@@ -60,11 +74,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_05_124031) do
   create_table "workout_blocks", force: :cascade do |t|
     t.integer "order_index"
     t.integer "duration"
-    t.string "block_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "target_ftp_percentage", precision: 10, scale: 2
     t.bigint "workout_summary_id", null: false
+    t.bigint "block_category_id", null: false
+    t.index ["block_category_id"], name: "index_workout_blocks_on_block_category_id"
     t.index ["workout_summary_id"], name: "index_workout_blocks_on_workout_summary_id"
   end
 
@@ -87,16 +102,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_05_124031) do
   create_table "workout_summaries", force: :cascade do |t|
     t.string "name"
     t.integer "total_duration"
-    t.string "category"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "category_id", null: false
+    t.index ["category_id"], name: "index_workout_summaries_on_category_id"
   end
 
   add_foreign_key "auth_tokens", "users"
   add_foreign_key "user_ftps", "users"
   add_foreign_key "workout_block_results", "workout_blocks"
   add_foreign_key "workout_block_results", "workout_results"
+  add_foreign_key "workout_blocks", "block_categories"
   add_foreign_key "workout_blocks", "workout_summaries"
   add_foreign_key "workout_results", "users"
   add_foreign_key "workout_results", "workout_summaries"
+  add_foreign_key "workout_summaries", "categories"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -7,188 +7,194 @@ puts "Creating Zwift-based cycling training menus..."
 # 既存のデータをクリア
 WorkoutSummary.destroy_all
 
+categories = Hash.new { |h, name| h[name] = Category.find_or_create_by!(name: name) }
+block_categories = Hash.new { |h, name| h[name] = BlockCategory.find_or_create_by!(name: name) }
+
+# order_indexによる連番は表示側の責務なので、block_categoryにはベースとなる
+# カテゴリ名のみを持たせる（「インターバル1」ではなく「インターバル」）。
+
 # 1. Sweet Spot Training (SST)
 sst_summary = WorkoutSummary.create!(
   name: "Sweet Spot Training (SST)",
   total_duration: 75, # 15分ウォームアップ + 3×15分 + 2×5分間 + 10分クールダウン
-  category: "FTP向上"
+  category: categories["FTP向上"]
 )
 
 sst_summary.workout_blocks.create!([
-  { order_index: 1, duration: 900, block_type: "ウォームアップ", target_ftp_percentage: 60 }, # 15分
-  { order_index: 2, duration: 900, block_type: "メインセット1", target_ftp_percentage: 90 }, # 15分
-  { order_index: 3, duration: 300, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 5分
-  { order_index: 4, duration: 900, block_type: "メインセット2", target_ftp_percentage: 90 }, # 15分
-  { order_index: 5, duration: 300, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 5分
-  { order_index: 6, duration: 900, block_type: "メインセット3", target_ftp_percentage: 90 }, # 15分
-  { order_index: 7, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+  { order_index: 1, duration: 900, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 }, # 15分
+  { order_index: 2, duration: 900, block_category: block_categories["メインセット"], target_ftp_percentage: 90 }, # 15分
+  { order_index: 3, duration: 300, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 5分
+  { order_index: 4, duration: 900, block_category: block_categories["メインセット"], target_ftp_percentage: 90 }, # 15分
+  { order_index: 5, duration: 300, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 5分
+  { order_index: 6, duration: 900, block_category: block_categories["メインセット"], target_ftp_percentage: 90 }, # 15分
+  { order_index: 7, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 ])
 
 # 2. VO2 Max Intervals - 強度を120-130%に修正
 vo2_summary = WorkoutSummary.create!(
   name: "VO2 Max Intervals",
   total_duration: 60, # 10分ウォームアップ + 6×3分 + 5×3分間 + 10分クールダウン
-  category: "最大酸素摂取量向上"
+  category: categories["最大酸素摂取量向上"]
 )
 
 vo2_summary.workout_blocks.create!([
-  { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 }, # 10分
-  { order_index: 2, duration: 180, block_type: "インターバル1", target_ftp_percentage: 125 }, # 3分 - 125%
-  { order_index: 3, duration: 180, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 3分
-  { order_index: 4, duration: 180, block_type: "インターバル2", target_ftp_percentage: 125 }, # 3分 - 125%
-  { order_index: 5, duration: 180, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 3分
-  { order_index: 6, duration: 180, block_type: "インターバル3", target_ftp_percentage: 125 }, # 3分 - 125%
-  { order_index: 7, duration: 180, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 3分
-  { order_index: 8, duration: 180, block_type: "インターバル4", target_ftp_percentage: 125 }, # 3分 - 125%
-  { order_index: 9, duration: 180, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 3分
-  { order_index: 10, duration: 180, block_type: "インターバル5", target_ftp_percentage: 125 }, # 3分 - 125%
-  { order_index: 11, duration: 180, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 3分
-  { order_index: 12, duration: 180, block_type: "インターバル6", target_ftp_percentage: 125 }, # 3分 - 125%
-  { order_index: 13, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+  { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 }, # 10分
+  { order_index: 2, duration: 180, block_category: block_categories["インターバル"], target_ftp_percentage: 125 }, # 3分 - 125%
+  { order_index: 3, duration: 180, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 3分
+  { order_index: 4, duration: 180, block_category: block_categories["インターバル"], target_ftp_percentage: 125 }, # 3分 - 125%
+  { order_index: 5, duration: 180, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 3分
+  { order_index: 6, duration: 180, block_category: block_categories["インターバル"], target_ftp_percentage: 125 }, # 3分 - 125%
+  { order_index: 7, duration: 180, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 3分
+  { order_index: 8, duration: 180, block_category: block_categories["インターバル"], target_ftp_percentage: 125 }, # 3分 - 125%
+  { order_index: 9, duration: 180, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 3分
+  { order_index: 10, duration: 180, block_category: block_categories["インターバル"], target_ftp_percentage: 125 }, # 3分 - 125%
+  { order_index: 11, duration: 180, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 3分
+  { order_index: 12, duration: 180, block_category: block_categories["インターバル"], target_ftp_percentage: 125 }, # 3分 - 125%
+  { order_index: 13, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 ])
 
 # 3. Threshold Intervals
 threshold_summary = WorkoutSummary.create!(
   name: "Threshold Intervals",
   total_duration: 70, # 10分ウォームアップ + 2×20分 + 10分間 + 10分クールダウン
-  category: "乳酸閾値向上"
+  category: categories["乳酸閾値向上"]
 )
 
 threshold_summary.workout_blocks.create!([
-  { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 }, # 10分
-  { order_index: 2, duration: 1200, block_type: "閾値セット1", target_ftp_percentage: 95 }, # 20分
-  { order_index: 3, duration: 600, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 10分
-  { order_index: 4, duration: 1200, block_type: "閾値セット2", target_ftp_percentage: 95 }, # 20分
-  { order_index: 5, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+  { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 }, # 10分
+  { order_index: 2, duration: 1200, block_category: block_categories["閾値セット"], target_ftp_percentage: 95 }, # 20分
+  { order_index: 3, duration: 600, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 10分
+  { order_index: 4, duration: 1200, block_category: block_categories["閾値セット"], target_ftp_percentage: 95 }, # 20分
+  { order_index: 5, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 ])
 
 # 4. Endurance Ride
 endurance_summary = WorkoutSummary.create!(
   name: "Endurance Ride",
   total_duration: 120, # 10分ウォームアップ + 2×45分 + 10分間 + 10分クールダウン
-  category: "基礎持久力向上"
+  category: categories["基礎持久力向上"]
 )
 
 endurance_summary.workout_blocks.create!([
-  { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 }, # 10分
-  { order_index: 2, duration: 2700, block_type: "エンデュランス1", target_ftp_percentage: 75 }, # 45分
-  { order_index: 3, duration: 600, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 10分
-  { order_index: 4, duration: 2700, block_type: "エンデュランス2", target_ftp_percentage: 75 }, # 45分
-  { order_index: 5, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+  { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 }, # 10分
+  { order_index: 2, duration: 2700, block_category: block_categories["エンデュランス"], target_ftp_percentage: 75 }, # 45分
+  { order_index: 3, duration: 600, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 10分
+  { order_index: 4, duration: 2700, block_category: block_categories["エンデュランス"], target_ftp_percentage: 75 }, # 45分
+  { order_index: 5, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 ])
 
 # 5. Sprint Intervals - 強度を150%に修正
 sprint_summary = WorkoutSummary.create!(
   name: "Sprint Intervals",
   total_duration: 75, # 10分ウォームアップ + 10×30秒 + 9×4分間 + 10分クールダウン
-  category: "短時間高出力向上"
+  category: categories["短時間高出力向上"]
 )
 
 sprint_blocks = []
-sprint_blocks << { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 } # 10分
+sprint_blocks << { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 } # 10分
 
 # 10回のスプリントインターバル - 150%の強度
 (1..10).each do |i|
-  sprint_blocks << { order_index: i * 2, duration: 30, block_type: "スプリント#{i}", target_ftp_percentage: 150 } # 30秒 - 150%
+  sprint_blocks << { order_index: i * 2, duration: 30, block_category: block_categories["スプリント"], target_ftp_percentage: 150 } # 30秒 - 150%
   if i < 10
-    sprint_blocks << { order_index: i * 2 + 1, duration: 240, block_type: "軽いペダリング", target_ftp_percentage: 50 } # 4分
+    sprint_blocks << { order_index: i * 2 + 1, duration: 240, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 } # 4分
   end
 end
 
-sprint_blocks << { order_index: 21, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+sprint_blocks << { order_index: 21, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 sprint_summary.workout_blocks.create!(sprint_blocks)
 
 # 6. Hill Climb Training
 hill_summary = WorkoutSummary.create!(
   name: "Hill Climb Training",
   total_duration: 65, # 10分ウォームアップ + 5×8分 + 4×5分間 + 10分クールダウン
-  category: "登坂能力向上"
+  category: categories["登坂能力向上"]
 )
 
 hill_blocks = []
-hill_blocks << { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 } # 10分
+hill_blocks << { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 } # 10分
 
 # 5回のヒルクライム
 (1..5).each do |i|
-  hill_blocks << { order_index: i * 2, duration: 480, block_type: "ヒルクライム#{i}", target_ftp_percentage: 100 } # 8分
+  hill_blocks << { order_index: i * 2, duration: 480, block_category: block_categories["ヒルクライム"], target_ftp_percentage: 100 } # 8分
   if i < 5
-    hill_blocks << { order_index: i * 2 + 1, duration: 300, block_type: "軽いペダリング", target_ftp_percentage: 50 } # 5分
+    hill_blocks << { order_index: i * 2 + 1, duration: 300, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 } # 5分
   end
 end
 
-hill_blocks << { order_index: 11, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+hill_blocks << { order_index: 11, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 hill_summary.workout_blocks.create!(hill_blocks)
 
 # 7. Tempo Ride
 tempo_summary = WorkoutSummary.create!(
   name: "Tempo Ride",
   total_duration: 85, # 10分ウォームアップ + 3×15分 + 2×8分間 + 10分クールダウン
-  category: "中強度持久力向上"
+  category: categories["中強度持久力向上"]
 )
 
 tempo_summary.workout_blocks.create!([
-  { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 }, # 10分
-  { order_index: 2, duration: 900, block_type: "テンポ1", target_ftp_percentage: 85 }, # 15分
-  { order_index: 3, duration: 480, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 8分
-  { order_index: 4, duration: 900, block_type: "テンポ2", target_ftp_percentage: 85 }, # 15分
-  { order_index: 5, duration: 480, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 8分
-  { order_index: 6, duration: 900, block_type: "テンポ3", target_ftp_percentage: 85 }, # 15分
-  { order_index: 7, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+  { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 }, # 10分
+  { order_index: 2, duration: 900, block_category: block_categories["テンポ"], target_ftp_percentage: 85 }, # 15分
+  { order_index: 3, duration: 480, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 8分
+  { order_index: 4, duration: 900, block_category: block_categories["テンポ"], target_ftp_percentage: 85 }, # 15分
+  { order_index: 5, duration: 480, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 8分
+  { order_index: 6, duration: 900, block_category: block_categories["テンポ"], target_ftp_percentage: 85 }, # 15分
+  { order_index: 7, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 ])
 
 # 8. Crit Race Simulation - 強度を110%に修正
 crit_summary = WorkoutSummary.create!(
   name: "Crit Race Simulation",
   total_duration: 80, # 10分ウォームアップ + 4セット(8×2分 + 7×2分間) + 10分クールダウン
-  category: "レース対応能力向上"
+  category: categories["レース対応能力向上"]
 )
 
 crit_blocks = []
-crit_blocks << { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 } # 10分
+crit_blocks << { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 } # 10分
 
 # 4セットのレースシミュレーション - ハード部分を110%に
 (1..4).each do |set|
   (1..8).each do |i|
-    crit_blocks << { order_index: (set - 1) * 16 + i * 2, duration: 120, block_type: "ハード#{set}-#{i}", target_ftp_percentage: 110 } # 2分 - 110%
+    crit_blocks << { order_index: (set - 1) * 16 + i * 2, duration: 120, block_category: block_categories["ハード"], target_ftp_percentage: 110 } # 2分 - 110%
     if i < 8
-      crit_blocks << { order_index: (set - 1) * 16 + i * 2 + 1, duration: 120, block_type: "イージー#{set}-#{i}", target_ftp_percentage: 65 } # 2分
+      crit_blocks << { order_index: (set - 1) * 16 + i * 2 + 1, duration: 120, block_category: block_categories["イージー"], target_ftp_percentage: 65 } # 2分
     end
   end
 end
 
-crit_blocks << { order_index: 65, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+crit_blocks << { order_index: 65, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 crit_summary.workout_blocks.create!(crit_blocks)
 
 # 9. Recovery Ride
 recovery_summary = WorkoutSummary.create!(
   name: "Recovery Ride",
   total_duration: 60, # 60分間の軽いペダリング
-  category: "回復促進"
+  category: categories["回復促進"]
 )
 
 recovery_summary.workout_blocks.create!([
-  { order_index: 1, duration: 3600, block_type: "リカバリーライド", target_ftp_percentage: 55 } # 60分
+  { order_index: 1, duration: 3600, block_category: block_categories["リカバリーライド"], target_ftp_percentage: 55 } # 60分
 ])
 
 # 10. Time Trial Practice
 tt_summary = WorkoutSummary.create!(
   name: "Time Trial Practice",
   total_duration: 75, # 10分ウォームアップ + 2×20分 + 15分間 + 10分クールダウン
-  category: "個人タイムトライアル対応"
+  category: categories["個人タイムトライアル対応"]
 )
 
 tt_summary.workout_blocks.create!([
-  { order_index: 1, duration: 600, block_type: "ウォームアップ", target_ftp_percentage: 60 }, # 10分
-  { order_index: 2, duration: 1200, block_type: "TTセット1", target_ftp_percentage: 95 }, # 20分
-  { order_index: 3, duration: 900, block_type: "軽いペダリング", target_ftp_percentage: 50 }, # 15分
-  { order_index: 4, duration: 1200, block_type: "TTセット2", target_ftp_percentage: 95 }, # 20分
-  { order_index: 5, duration: 600, block_type: "クールダウン", target_ftp_percentage: 50 } # 10分
+  { order_index: 1, duration: 600, block_category: block_categories["ウォームアップ"], target_ftp_percentage: 60 }, # 10分
+  { order_index: 2, duration: 1200, block_category: block_categories["TTセット"], target_ftp_percentage: 95 }, # 20分
+  { order_index: 3, duration: 900, block_category: block_categories["軽いペダリング"], target_ftp_percentage: 50 }, # 15分
+  { order_index: 4, duration: 1200, block_category: block_categories["TTセット"], target_ftp_percentage: 95 }, # 20分
+  { order_index: 5, duration: 600, block_category: block_categories["クールダウン"], target_ftp_percentage: 50 } # 10分
 ])
 
 puts "Created #{WorkoutSummary.count} training menus with #{WorkoutBlock.count} total blocks"
 puts "Training menus:"
-WorkoutSummary.all.each do |summary|
-  puts "- #{summary.name} (#{summary.category}) - #{summary.total_duration}分"
+WorkoutSummary.includes(:category).each do |summary|
+  puts "- #{summary.name} (#{summary.category.name}) - #{summary.total_duration}分"
 end
 
 puts "\n強度設定の確認:"

--- a/backend/spec/factories/block_categories.rb
+++ b/backend/spec/factories/block_categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :block_category do
+    sequence(:name) { |n| "block-category-#{n}" }
+  end
+end

--- a/backend/spec/factories/categories.rb
+++ b/backend/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "category-#{n}" }
+  end
+end

--- a/backend/spec/factories/workout_blocks.rb
+++ b/backend/spec/factories/workout_blocks.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     order_index { 0 }
     target_ftp_percentage { rand(50..150) }
     duration { rand(60..600) }
-    block_type { %w[warmup work rest cooldown].sample }
+    association :block_category
   end
 end

--- a/backend/spec/factories/workout_summaries.rb
+++ b/backend/spec/factories/workout_summaries.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :workout_summary do
     name { Faker::Lorem.words(number: 3).join(' ') }
     total_duration { rand(1800..7200) }
-    category { %w[endurance tempo sweet_spot threshold vo2max sprint recovery].sample }
+    association :category
   end
 end

--- a/backend/spec/models/block_category_spec.rb
+++ b/backend/spec/models/block_category_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe BlockCategory, type: :model do
+  describe 'associations' do
+    it { should have_many(:workout_blocks) }
+  end
+
+  describe 'validations' do
+    subject { create(:block_category) }
+
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+  end
+end

--- a/backend/spec/models/category_spec.rb
+++ b/backend/spec/models/category_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'associations' do
+    it { should have_many(:workout_summaries) }
+  end
+
+  describe 'validations' do
+    subject { create(:category) }
+
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+  end
+end

--- a/backend/spec/models/workout_block_spec.rb
+++ b/backend/spec/models/workout_block_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe WorkoutBlock, type: :model do
   describe 'associations' do
     it { should belong_to(:workout_summary) }
+    it { should belong_to(:block_category) }
   end
 
   describe 'factory' do
@@ -30,7 +31,7 @@ RSpec.describe WorkoutBlock, type: :model do
       expect(workout_block).to respond_to(:order_index)
       expect(workout_block).to respond_to(:target_ftp_percentage)
       expect(workout_block).to respond_to(:duration)
-      expect(workout_block).to respond_to(:block_type)
+      expect(workout_block).to respond_to(:block_category)
     end
   end
 end

--- a/backend/spec/models/workout_summary_spec.rb
+++ b/backend/spec/models/workout_summary_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe WorkoutSummary, type: :model do
   describe 'associations' do
+    it { should belong_to(:category) }
     it { should have_many(:workout_blocks).dependent(:destroy) }
   end
 

--- a/backend/spec/requests/api/v1/workout_blocks_spec.rb
+++ b/backend/spec/requests/api/v1/workout_blocks_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe 'API::V1::WorkoutBlocks', type: :request do
           expect(block['workout_summary_id']).to eq(workout_summary.id)
         end
       end
+
+      it 'exposes block_type as the block_category name' do
+        json_response = JSON.parse(response.body)
+
+        expect(json_response[0]['block_type']).to eq(workout_blocks[0].block_category.name)
+      end
     end
 
     context 'when no workout blocks exist for the summary' do

--- a/backend/spec/requests/api/v1/workout_summaries_spec.rb
+++ b/backend/spec/requests/api/v1/workout_summaries_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe 'API::V1::WorkoutSummaries', type: :request do
         expect(first_summary).to have_key('updated_at')
       end
 
+      it 'exposes category as the category name' do
+        json_response = JSON.parse(response.body)
+        expect(json_response.first['category']).to eq(workout_summaries.first.category.name)
+      end
+
       it 'does not expose internal attributes' do
         json_response = JSON.parse(response.body)
         first_summary = json_response.first


### PR DESCRIPTION
## Summary
`workout_summaries.category`と`workout_blocks.block_type`がバリデーション/DB制約の無い自由文字列だった問題を正規化。特に`block_type`は「メインセット1」のようにカテゴリ名と表示用連番が同じ文字列に混在していた。

- `categories`/`block_categories`テーブルを新設（name一意制約）
- `workout_summaries.category_id`/`workout_blocks.block_category_id`をFK化（NOT NULL）
- マイグレーションで既存データを自動移行（本番DB確認済み: category 10種類、block_category 14種類に正規化）
- 移行後、`category`/`block_type`カラムは削除
- `db/seeds.rb`を書き換え（生成されるブロック数137件は移行前と同一であることを確認済み）

APIレスポンスの`category`/`block_type`キーは引き続き文字列を返すため、**フロントエンドの変更は不要**です。

## ⚠️ 挙動変更（要確認）
`block_type`に埋め込まれていた表示用連番（「メインセット1」「インターバル2」等）は今後返らず、カテゴリ名のみ（「メインセット」「インターバル」）になります。ワークアウト画面は現在ブロックをハイライト付きリストで位置表示しているため実用上は問題ないと判断していますが、見た目が変わる点はご確認ください。

## Test plan
- [x] `bundle exec rspec` — 114/114 pass
- [x] `bundle exec rails db:seed`（development）で137ブロック生成を確認、正規化後のcategory/block_categoryの値を目視確認
- [x] 本番DBで移行対象データの分布を事前確認済み