### PR TITLE
fix: BLEスキャンをパワーメーターに絞り検索画面UIを改善

### DIFF
--- a/frontend/lib/data/ble_connector.dart
+++ b/frontend/lib/data/ble_connector.dart
@@ -37,9 +37,11 @@ class BleConnector {
       controller.addError(e); // エラーが発生した場合、Streamにエラーを追加
     });
 
-    // システムデバイスを取得してスキャンを開始します。
-    FlutterBluePlus.systemDevices([Guid("180f")]);
-    FlutterBluePlus.startScan(timeout: const Duration(seconds: 300));
+    // Cycling Power Service (0x1818) を持つデバイスのみをスキャン対象にする
+    FlutterBluePlus.startScan(
+      timeout: const Duration(seconds: 300),
+      withServices: [Guid("1818")],
+    );
 
     return controller.stream;
   }

--- a/frontend/lib/ui/ble_setting/scan_screen.dart
+++ b/frontend/lib/ui/ble_setting/scan_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:workoutride/di/providers.dart';
+import 'package:workoutride/domain/model/device_scan_result.dart';
 import 'package:workoutride/ui/ble_setting/scan_screen_state_notifier.dart';
 
 class ScanScreen extends HookConsumerWidget {
@@ -47,56 +48,94 @@ class ScanScreen extends HookConsumerWidget {
       backgroundColor: Colors.black,
       body: Stack(
         children: [
-          SingleChildScrollView(
-            child: Column(
-              children: <Widget>[
-                if (uiState.errorMessage != null)
-                  Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Text(
-                      uiState.errorMessage!,
-                      style: const TextStyle(color: Colors.red),
-                    ),
-                  ),
-                for (final result in uiState.scanResults)
-                  DeviceListTile(
-                    title: result.deviceName,
-                    onTap: () {
-                      ref
-                          .read(scanScreenStateNotifierProvider.notifier)
-                          .onDeviceTap(result);
-                    },
-                  ),
-                if (uiState.scanResults.isEmpty && !uiState.isScanning)
-                  const Padding(
-                    padding: EdgeInsets.all(32),
-                    child: Column(
-                      children: [
-                        Icon(Icons.bluetooth_searching,
-                            size: 48, color: Colors.grey),
-                        SizedBox(height: 16),
-                        Text(
-                          'デバイスが見つかりません',
-                          style: TextStyle(fontSize: 16, color: Colors.grey),
+          Column(
+            children: [
+              if (uiState.isScanning)
+                const LinearProgressIndicator(
+                  backgroundColor: Colors.grey,
+                  valueColor: AlwaysStoppedAnimation(Colors.orange),
+                ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      if (uiState.errorMessage != null)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 16.0),
+                          child: Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Colors.red.withValues(alpha: 0.1),
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(color: Colors.red),
+                            ),
+                            child: Text(
+                              uiState.errorMessage!,
+                              style: const TextStyle(color: Colors.red),
+                            ),
+                          ),
                         ),
-                        SizedBox(height: 8),
-                        Text(
-                          'Bluetoothをオンにして、デバイスを近くに置いてください',
-                          textAlign: TextAlign.center,
-                          style: TextStyle(fontSize: 12, color: Colors.grey),
+                      Text(
+                        uiState.isScanning
+                            ? 'パワーメーターを検索しています…'
+                            : '${uiState.scanResults.length}件見つかりました',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.grey[400],
                         ),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(height: 12),
+                      for (final result in uiState.scanResults)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 10),
+                          child: DeviceListTile(
+                            result: result,
+                            onTap: () {
+                              ref
+                                  .read(
+                                      scanScreenStateNotifierProvider.notifier)
+                                  .onDeviceTap(result);
+                            },
+                          ),
+                        ),
+                      if (uiState.scanResults.isEmpty && !uiState.isScanning)
+                        const Padding(
+                          padding: EdgeInsets.only(top: 48),
+                          child: Column(
+                            children: [
+                              Icon(Icons.bluetooth_searching,
+                                  size: 48, color: Colors.grey),
+                              SizedBox(height: 16),
+                              Text(
+                                'パワーメーターが見つかりません',
+                                style:
+                                    TextStyle(fontSize: 16, color: Colors.grey),
+                              ),
+                              SizedBox(height: 8),
+                              Text(
+                                'Bluetoothをオンにして、デバイスを近くに置いてください',
+                                textAlign: TextAlign.center,
+                                style:
+                                    TextStyle(fontSize: 12, color: Colors.grey),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
                   ),
-                const Padding(padding: EdgeInsets.symmetric(vertical: 16)),
-              ],
-            ),
+                ),
+              ),
+            ],
           ),
           if (uiState.isConnecting)
             Container(
               color: Colors.black.withValues(alpha: 0.5),
               child: const Center(
-                child: CircularProgressIndicator(),
+                child: CircularProgressIndicator(color: Colors.orange),
               ),
             ),
         ],
@@ -108,30 +147,43 @@ class ScanScreen extends HookConsumerWidget {
 class DeviceListTile extends StatelessWidget {
   const DeviceListTile({
     super.key,
-    required this.title,
+    required this.result,
     required this.onTap,
   });
 
-  final String title;
+  final DeviceScanResult result;
   final VoidCallback onTap;
+
+  IconData get _signalIcon {
+    if (result.rssi >= -60) return Icons.signal_cellular_alt;
+    if (result.rssi >= -80) return Icons.signal_cellular_alt_2_bar;
+    return Icons.signal_cellular_alt_1_bar;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Column(
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontSize: 20,
-                color: Colors.white,
-              ),
-            ),
-          ],
+    return Card(
+      color: Colors.grey[900],
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: const Icon(Icons.bolt, color: Colors.orange),
+        title: Text(
+          result.deviceName,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
         ),
+        subtitle: Text(
+          result.deviceAddress,
+          style: TextStyle(
+            color: Colors.grey[400],
+            fontSize: 12,
+          ),
+        ),
+        trailing: Icon(_signalIcon, color: Colors.grey[400], size: 20),
+        onTap: onTap,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- BLEスキャンをCycling Power Service (0x1818) でフィルタし、無関係なデバイスが一覧に出ないようにした
- 検索画面をカードUI（アイコン・電波強度表示付き）に刷新し、スキャン中表示と件数表示を追加

## Test plan
- [x] `flutter analyze` クリーン
- [ ] 実機でパワーメーターがスキャン結果に表示されることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dm9HpHhhksjJ4Bjtszmhcn