### PR TITLE
chore: バージョンを1.0.0+2に更新

### DIFF
--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: '>=3.3.1 <4.0.0'


### PR DESCRIPTION
## Summary
- Play Consoleクローズドテスト向けAABアップロードのため、versionCodeを1.0.0+1 → 1.0.0+2に更新

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dm9HpHhhksjJ4Bjtszmhcn